### PR TITLE
GeekBench support

### DIFF
--- a/zluda/src/impl/function.rs
+++ b/zluda/src/impl/function.rs
@@ -26,6 +26,7 @@ pub struct FunctionData {
     pub arg_size: Vec<usize>,
     pub use_shared_mem: bool,
     pub properties: Option<Box<l0::sys::ze_kernel_properties_t>>,
+    pub do_nothing_hack: bool,
 }
 
 impl FunctionData {
@@ -61,6 +62,9 @@ pub fn launch_kernel(
     }
     GlobalState::lock_stream(hstream, |stream| {
         let func: &mut FunctionData = unsafe { &mut *f }.as_result_mut()?;
+        if func.do_nothing_hack {
+            return Ok(());
+        }
         for (i, arg_size) in func.arg_size.iter().enumerate() {
             unsafe {
                 func.base


### PR DESCRIPTION
This is the tracking issue for failing GeekBench workloads:

- [x] Depth of Field\
Seems to be a problem with `TRIVIAL_RA`. Works with `IGC_VISAOptions="-nolocalra"` environment variable which effectively disables `TRIVIAL_RA`. Need to report to IGC team
- [x] Histogram Equalization
- [x] Face Detection
- [x] Feature Matching
- [x] Particle Physics
- [x] SFFT\
All five above currently give very worrying  debug spew (if the compiler was built in `DEBUG`) about assembly operand regions being wider than 2 GRFs. Currently pending more debug. Additionally Face Detection and Particle Physics hang with `IGC_VISAOptions="-nolocalra" `.