### PR TITLE
Add empty implementation of cuDeviceGetLuid

### DIFF
--- a/zluda/src/cuda.rs
+++ b/zluda/src/cuda.rs
@@ -2233,6 +2233,15 @@ pub extern "C" fn cuDeviceGetUuid(uuid: *mut CUuuid, dev: CUdevice) -> CUresult 
 }
 
 #[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn cuDeviceGetLuid(
+    luid: *mut ::std::os::raw::c_char,
+    deviceNodeMask: *mut ::std::os::raw::c_uint,
+    dev: CUdevice,
+) -> CUresult {
+    r#impl::device::get_luid(luid, deviceNodeMask, dev.decuda()).encuda()
+}
+
+#[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn cuDeviceTotalMem_v2(bytes: *mut usize, dev: CUdevice) -> CUresult {
     r#impl::device::total_mem_v2(bytes, dev.decuda()).encuda()
 }

--- a/zluda/src/impl/device.rs
+++ b/zluda/src/impl/device.rs
@@ -3,7 +3,7 @@ use crate::cuda;
 use cuda::{CUdevice_attribute, CUuuid_st};
 use std::{
     cmp, mem,
-    os::raw::{c_char, c_int},
+    os::raw::{c_char, c_int, c_uint},
     ptr,
     sync::atomic::{AtomicU32, Ordering},
 };
@@ -347,6 +347,13 @@ pub fn get_uuid(uuid: *mut CUuuid_st, dev_idx: Index) -> Result<(), CUresult> {
             bytes: mem::transmute(ze_uuid.id),
         }
     };
+    Ok(())
+}
+
+// TODO: add support if Level 0 exposes it
+pub fn get_luid(luid: *mut c_char, dev_node_mask: *mut c_uint, _dev_idx: Index) -> Result<(), CUresult> {
+    unsafe { ptr::write_bytes(luid, 0u8, 8) };
+    unsafe { *dev_node_mask = 0 };
     Ok(())
 }
 


### PR DESCRIPTION
This function is required by recent versions of CUDA runtime on Windows