### PR TITLE
Add script for replaying dumped kernel

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ When running an application with ZLUDA quite often you will run into subtle bugs
 
 Library `zluda_dump` can be injected into a CUDA application and produce a trace which, for every launched GPU function contains:
 * PTX source
-* Launch arguments (block size, grid size, shared memory)
-* Memory dump of global meory used by the function. Both after and before
+* Launch arguments (block size, grid size, shared memory size)
+* Dump of function arguments. Both after and before
 
 Example use with GeekBench:
 ```
@@ -41,7 +41,7 @@ This dump can be replayed with `replay.py` script from `zluda_dump` source direc
 ```
 python replay.py "C:\temp\zluda_dump\geekbench_x86_64.exe"
 ```
-You must copy (or symlink) ZLUDA nvcuda.dll into pyCUDA directory, so it will run using ZLUDA. This will print similar information to stdout:
+You must copy (or symlink) ZLUDA `nvcuda.dll` into PyCUDA directory, so it will run using ZLUDA. Example output:
 ```
 Intel(R) Graphics [0x3e92] [github.com/vosen/ZLUDA]
 C:\temp\zluda_dump\geekbench_x86_64.exe\4140_scale_pyramid
@@ -57,5 +57,5 @@ Max relative difference: 255.
  x: array([  7,   6,   8, ..., 193, 195, 193], dtype=uint8)
  y: array([  7,   6,   8, ..., 193, 195, 193], dtype=uint8)
 ```
-From this output one can observe that in kernel launch 4480, 6th argument to function `scale_pyramid` differs between what was executed on an NVIDIA GPU and Intel GPU using CUDA.  
+From this output one can observe that in kernel launch 4480, 6th argument to function `scale_pyramid` differs between what was executed on an NVIDIA GPU using CUDA and Intel GPU using ZLUDA.  
 __Important__: It's impossible to infer what was the type (and semantics) of argument passed to a GPU function. At our level it's a buffer of bytes and by default `replay.py` simply checks if two buffers are byte-equal. That means you will have a ton of false negatives when running  `replay.py`. You should override them for your particular case in `replay.py` - it already contains some overrides for GeekBench kernels

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,61 @@
-## Dependencies
+# Dependencies
 
 Development builds of ZLUDA requires following dependencies:
 
 * CMake
 * Python 3
 
-Additionally repository have to be clone with Git submodules initalized. If you cloned the repo without initalizing submodules, do this:
+Additionally the repository has to be cloned with Git submodules initalized. If you cloned the repo without initalizing submodules, do this:
 ```
 git submodule update --init --recursive
 ```
 
-## Tests
+# Tests
 
 Tests should be executed with `--workspace` option to test non-default targets:
 ```
 cargo test --workspace
 ```
+
+# Debugging
+
+## Debuggging CUDA applications
+
+When running an application with ZLUDA quite often you will run into subtle bugs or incompatibilities in the generated GPU code. The best way to debug an application's GPU CUDA code is to use ZLUDA dumper.
+
+Library `zluda_dump` can be injected into a CUDA application and produce a trace which, for every launched GPU function contains:
+* PTX source
+* Launch arguments (block size, grid size, shared memory)
+* Memory dump of global meory used by the function. Both after and before
+
+Example use with GeekBench:
+```
+set ZLUDA_DUMP_KERNEL=knn_match
+set ZLUDA_DUMP_DIR=C:\temp\zluda_dump
+"<ZLUDA_PATH>\zluda_with.exe" "<ZLUDA_PATH>\zluda_dump.dll" -- "geekbench_x86_64.exe" --compute CUDA
+```
+
+The example above, for every execution of GPU function `knn_match`, will save its details into the directory `C:\temp\zluda_dump`
+
+This dump can be replayed with `replay.py` script from `zluda_dump` source directory. Use it like this:
+```
+python replay.py "C:\temp\zluda_dump\geekbench_x86_64.exe"
+```
+You must copy (or symlink) ZLUDA nvcuda.dll into pyCUDA directory, so it will run using ZLUDA. This will print similar information to stdout:
+```
+Intel(R) Graphics [0x3e92] [github.com/vosen/ZLUDA]
+C:\temp\zluda_dump\geekbench_x86_64.exe\4140_scale_pyramid
+C:\temp\zluda_dump\geekbench_x86_64.exe\4345_convolve_1d_vertical_grayscale
+    Skipping, launch block size (512) bigger than maximum block size (256)
+C:\temp\zluda_dump\geekbench_x86_64.exe\4480_scale_pyramid
+6: 
+Arrays are not equal
+
+Mismatched elements: 1200 / 19989588 (0.006%)
+Max absolute difference: 255
+Max relative difference: 255.
+ x: array([  7,   6,   8, ..., 193, 195, 193], dtype=uint8)
+ y: array([  7,   6,   8, ..., 193, 195, 193], dtype=uint8)
+```
+From this output one can observe that in kernel launch 4480, 6th argument to function `scale_pyramid` differs between what was executed on an NVIDIA GPU and Intel GPU using CUDA.  
+__Important__: It's impossible to infer what was the type (and semantics) of argument passed to a GPU function. At our level it's a buffer of bytes and by default `replay.py` simply checks if two buffers are byte-equal. That means you will have a ton of false negatives when running  `replay.py`. You should override them for your particular case in `replay.py` - it already contains some overrides for GeekBench kernels

--- a/zluda/src/cuda.rs
+++ b/zluda/src/cuda.rs
@@ -4503,3 +4503,33 @@ pub extern "C" fn cuGetExportTable(
 pub extern "C" fn cuFuncGetModule(hmod: *mut CUmodule, hfunc: CUfunction) -> CUresult {
     r#impl::unimplemented()
 }
+
+impl CUoutput_mode_enum {
+    pub const CU_OUT_KEY_VALUE_PAIR: CUoutput_mode_enum = CUoutput_mode_enum(0);
+}
+impl CUoutput_mode_enum {
+    pub const CU_OUT_CSV: CUoutput_mode_enum = CUoutput_mode_enum(1);
+}
+#[repr(transparent)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub struct CUoutput_mode_enum(pub ::std::os::raw::c_uint);
+pub use self::CUoutput_mode_enum as CUoutput_mode;
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn cuProfilerInitialize(
+    configFile: *const ::std::os::raw::c_char,
+    outputFile: *const ::std::os::raw::c_char,
+    outputMode: CUoutput_mode,
+) -> CUresult {
+    r#impl::unimplemented()
+}
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn cuProfilerStart() -> CUresult {
+    r#impl::unimplemented()
+}
+
+#[cfg_attr(not(test), no_mangle)]
+pub extern "C" fn cuProfilerStop() -> CUresult {
+    r#impl::unimplemented()
+}

--- a/zluda/src/cuda.rs
+++ b/zluda/src/cuda.rs
@@ -2186,7 +2186,7 @@ pub extern "C" fn cuGetErrorString(
     error: CUresult,
     pStr: *mut *const ::std::os::raw::c_char,
 ) -> CUresult {
-    r#impl::unimplemented()
+    r#impl::get_error_string(error,  pStr).encuda()
 }
 
 #[cfg_attr(not(test), no_mangle)]
@@ -2344,7 +2344,7 @@ pub extern "C" fn cuCtxDestroy_v2(ctx: CUcontext) -> CUresult {
 
 #[cfg_attr(not(test), no_mangle)]
 pub extern "C" fn cuCtxPushCurrent_v2(ctx: CUcontext) -> CUresult {
-    r#impl::unimplemented()
+    r#impl::context::push_current_v2(ctx.decuda())
 }
 
 #[cfg_attr(not(test), no_mangle)]
@@ -2443,7 +2443,7 @@ pub extern "C" fn cuModuleLoad(
     module: *mut CUmodule,
     fname: *const ::std::os::raw::c_char,
 ) -> CUresult {
-    r#impl::unimplemented()
+    r#impl::module::load(module.decuda(), fname).encuda()
 }
 
 #[cfg_attr(not(test), no_mangle)]
@@ -3671,7 +3671,7 @@ pub extern "C" fn cuFuncSetBlockShape(
     y: ::std::os::raw::c_int,
     z: ::std::os::raw::c_int,
 ) -> CUresult {
-    r#impl::unimplemented()
+    r#impl::function::set_block_shape(hfunc.decuda(), x, y, z).encuda()
 }
 
 #[cfg_attr(not(test), no_mangle)]

--- a/zluda/src/impl/context.rs
+++ b/zluda/src/impl/context.rs
@@ -169,6 +169,14 @@ pub fn destroy_v2(ctx: *mut Context) -> Result<(), CUresult> {
     GlobalState::lock(|_| Context::destroy_impl(ctx))?
 }
 
+pub(crate) fn push_current_v2(pctx: *mut Context) -> CUresult {
+    if pctx == ptr::null_mut() {
+        return CUresult::CUDA_ERROR_INVALID_VALUE;
+    }
+    CONTEXT_STACK.with(|stack| stack.borrow_mut().push(pctx));
+    CUresult::CUDA_SUCCESS
+}
+
 pub fn pop_current_v2(pctx: *mut *mut Context) -> CUresult {
     if pctx == ptr::null_mut() {
         return CUresult::CUDA_ERROR_INVALID_VALUE;

--- a/zluda/src/impl/function.rs
+++ b/zluda/src/impl/function.rs
@@ -40,6 +40,7 @@ impl LegacyArguments {
         LegacyArguments { block_shape: None }
     }
 
+    #[allow(dead_code)]
     pub fn is_initialized(&self) -> bool {
         self.block_shape.is_some()
     }

--- a/zluda/src/impl/mod.rs
+++ b/zluda/src/impl/mod.rs
@@ -306,6 +306,110 @@ pub fn init() -> Result<(), CUresult> {
     Ok(())
 }
 
+macro_rules! stringify_curesult {
+    ($x:ident => [ $($variant:ident),+ ]) => {
+        match $x {
+            $(
+                CUresult::$variant => Some(concat!(stringify!($variant), "\0")),
+            )+
+            _ => None
+        }
+    }
+}
+
+pub(crate) fn get_error_string(error: CUresult, str: *mut *const i8) -> CUresult {
+    if str == ptr::null_mut() {
+        return CUresult::CUDA_ERROR_INVALID_VALUE;
+    }
+    let text = stringify_curesult!(
+        error => [
+            CUDA_SUCCESS,
+            CUDA_ERROR_INVALID_VALUE,
+            CUDA_ERROR_OUT_OF_MEMORY,
+            CUDA_ERROR_NOT_INITIALIZED,
+            CUDA_ERROR_DEINITIALIZED,
+            CUDA_ERROR_PROFILER_DISABLED,
+            CUDA_ERROR_PROFILER_NOT_INITIALIZED,
+            CUDA_ERROR_PROFILER_ALREADY_STARTED,
+            CUDA_ERROR_PROFILER_ALREADY_STOPPED,
+            CUDA_ERROR_NO_DEVICE,
+            CUDA_ERROR_INVALID_DEVICE,
+            CUDA_ERROR_INVALID_IMAGE,
+            CUDA_ERROR_INVALID_CONTEXT,
+            CUDA_ERROR_CONTEXT_ALREADY_CURRENT,
+            CUDA_ERROR_MAP_FAILED,
+            CUDA_ERROR_UNMAP_FAILED,
+            CUDA_ERROR_ARRAY_IS_MAPPED,
+            CUDA_ERROR_ALREADY_MAPPED,
+            CUDA_ERROR_NO_BINARY_FOR_GPU,
+            CUDA_ERROR_ALREADY_ACQUIRED,
+            CUDA_ERROR_NOT_MAPPED,
+            CUDA_ERROR_NOT_MAPPED_AS_ARRAY,
+            CUDA_ERROR_NOT_MAPPED_AS_POINTER,
+            CUDA_ERROR_ECC_UNCORRECTABLE,
+            CUDA_ERROR_UNSUPPORTED_LIMIT,
+            CUDA_ERROR_CONTEXT_ALREADY_IN_USE,
+            CUDA_ERROR_PEER_ACCESS_UNSUPPORTED,
+            CUDA_ERROR_INVALID_PTX,
+            CUDA_ERROR_INVALID_GRAPHICS_CONTEXT,
+            CUDA_ERROR_NVLINK_UNCORRECTABLE,
+            CUDA_ERROR_JIT_COMPILER_NOT_FOUND,
+            CUDA_ERROR_INVALID_SOURCE,
+            CUDA_ERROR_FILE_NOT_FOUND,
+            CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND,
+            CUDA_ERROR_SHARED_OBJECT_INIT_FAILED,
+            CUDA_ERROR_OPERATING_SYSTEM,
+            CUDA_ERROR_INVALID_HANDLE,
+            CUDA_ERROR_ILLEGAL_STATE,
+            CUDA_ERROR_NOT_FOUND,
+            CUDA_ERROR_NOT_READY,
+            CUDA_ERROR_ILLEGAL_ADDRESS,
+            CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES,
+            CUDA_ERROR_LAUNCH_TIMEOUT,
+            CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING,
+            CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED,
+            CUDA_ERROR_PEER_ACCESS_NOT_ENABLED,
+            CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE,
+            CUDA_ERROR_CONTEXT_IS_DESTROYED,
+            CUDA_ERROR_ASSERT,
+            CUDA_ERROR_TOO_MANY_PEERS,
+            CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED,
+            CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED,
+            CUDA_ERROR_HARDWARE_STACK_ERROR,
+            CUDA_ERROR_ILLEGAL_INSTRUCTION,
+            CUDA_ERROR_MISALIGNED_ADDRESS,
+            CUDA_ERROR_INVALID_ADDRESS_SPACE,
+            CUDA_ERROR_INVALID_PC,
+            CUDA_ERROR_LAUNCH_FAILED,
+            CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE,
+            CUDA_ERROR_NOT_PERMITTED,
+            CUDA_ERROR_NOT_SUPPORTED,
+            CUDA_ERROR_SYSTEM_NOT_READY,
+            CUDA_ERROR_SYSTEM_DRIVER_MISMATCH,
+            CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE,
+            CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED,
+            CUDA_ERROR_STREAM_CAPTURE_INVALIDATED,
+            CUDA_ERROR_STREAM_CAPTURE_MERGE,
+            CUDA_ERROR_STREAM_CAPTURE_UNMATCHED,
+            CUDA_ERROR_STREAM_CAPTURE_UNJOINED,
+            CUDA_ERROR_STREAM_CAPTURE_ISOLATION,
+            CUDA_ERROR_STREAM_CAPTURE_IMPLICIT,
+            CUDA_ERROR_CAPTURED_EVENT,
+            CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD,
+            CUDA_ERROR_TIMEOUT,
+            CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE,
+            CUDA_ERROR_UNKNOWN
+        ]
+    );
+    match text {
+        Some(text) => {
+            unsafe { *str = text.as_ptr() as *const _ };
+            CUresult::CUDA_SUCCESS
+        }
+        None => CUresult::CUDA_ERROR_INVALID_VALUE,
+    }
+}
+
 unsafe fn transmute_lifetime_mut<'a, 'b, T: ?Sized>(t: &'a mut T) -> &'b mut T {
     mem::transmute(t)
 }

--- a/zluda/src/impl/mod.rs
+++ b/zluda/src/impl/mod.rs
@@ -138,10 +138,10 @@ impl From<l0::sys::ze_result_t> for CUresult {
             l0_sys::ze_result_t::ZE_RESULT_ERROR_UNINITIALIZED => {
                 CUresult::CUDA_ERROR_NOT_INITIALIZED
             }
-            l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_ENUMERATION => {
-                CUresult::CUDA_ERROR_INVALID_VALUE
-            }
-            l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_ARGUMENT => {
+            l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_ENUMERATION
+            | l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_ARGUMENT
+            | l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_GROUP_SIZE_DIMENSION
+            | l0_sys::ze_result_t::ZE_RESULT_ERROR_INVALID_GLOBAL_WIDTH_DIMENSION => {
                 CUresult::CUDA_ERROR_INVALID_VALUE
             }
             l0_sys::ze_result_t::ZE_RESULT_ERROR_OUT_OF_HOST_MEMORY => {

--- a/zluda_dump/src/replay.py
+++ b/zluda_dump/src/replay.py
@@ -1,0 +1,59 @@
+import pycuda.autoinit
+import pycuda.driver as drv
+import pycuda.tools as py_tools
+from pathlib import PurePath
+import numpy as np
+from os import path
+import os
+import itertools
+
+
+def load_arguments(arg_path):
+    is_buffer = arg_path.endswith(".buffer")
+    with open(arg_path, "rb") as f:
+        arg_bytes = f.read()
+    if not is_buffer:
+        if len(arg_bytes) == 1:
+            return np.frombuffer(arg_bytes, dtype=np.uint8)[0], None
+        elif len(arg_bytes) == 2:
+            return np.frombuffer(arg_bytes, dtype=np.uint16)[0], None
+        elif len(arg_bytes) == 4:
+            return np.frombuffer(arg_bytes, dtype=np.uint32)[0], None
+        elif len(arg_bytes) == 8:
+            return np.frombuffer(arg_bytes, dtype=np.uint64)[0], None
+        else:
+            raise Exception('Incorrect size of {}: {}'.format(arg_path, len(arg_bytes)))
+    else:
+        buff = np.frombuffer(bytearray(arg_bytes), dtype=np.uint8)
+        buff.setflags(write=1, align=1)
+        return drv.InOut(buff), buff
+
+
+def parse_arguments(dump_path, prefix):
+    dir = path.join(dump_path, prefix)
+    arg_files = os.listdir(dir)
+    return [load_arguments(path.join(dir, f)) for f in sorted(arg_files)]
+
+
+PATH = r"D:\temp\zluda_dump\geekbench_x86_64.exe\4440_knn_match"
+kernel_name = path.basename(PATH).split("_", 1)[1]
+with open(path.join(PATH, "launch.txt"), "r") as launch_f:
+    launch_lines = list(map(int, launch_f.readlines()))
+assert launch_lines[6] == 0  # we don't support dynamic shared memory in replay yet
+device = drv.Device(0)
+print(device.name())
+module = drv.module_from_file(path.join(PATH, "module.ptx"))
+kernel = module.get_function(kernel_name)
+pre_args = parse_arguments(PATH, "pre")
+post_args = parse_arguments(PATH, "pre")
+kernel_pre_args, host_pre_args = zip(*pre_args)
+kernel(*list(kernel_pre_args), block=tuple(launch_lines[:3]), grid=tuple(launch_lines[3:6]))
+_, host_post_args_args = zip(*post_args)
+for idx, (pre_arg, post_arg) in enumerate(zip(host_pre_args, host_post_args_args)):
+    if pre_arg is None:
+        continue
+    try:
+        np.testing.assert_array_equal(pre_arg, post_arg)
+    except Exception as e:
+        print(f"{idx}: {e}")
+

--- a/zluda_dump/src/replay.py
+++ b/zluda_dump/src/replay.py
@@ -55,7 +55,7 @@ def verify_single_dump(input_path):
     kernel = module.get_function(kernel_name)
     pre_args = parse_arguments(input_path, "pre")
     kernel_pre_args, host_pre_args = zip(*pre_args)
-    kernel(*list(kernel_pre_args), block=tuple(launch_lines[:3]), grid=tuple(launch_lines[3:6]))
+    kernel(*list(kernel_pre_args), grid=tuple(launch_lines[:3]), block=tuple(launch_lines[3:6]))
     post_args = parse_arguments(input_path, "post")
     _, host_post_args_args = zip(*post_args)
     for idx, (pre_arg, post_arg) in enumerate(zip(host_pre_args, host_post_args_args)):


### PR DESCRIPTION
In #18 we gained ability to dump before/after arguments of CUDA kernel launches. Now, this script will add ability to actually execute this dump and verify if results are correct