### PR TITLE
Improve ZLUDA injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,16 @@ Overall, ZLUDA is slower in GeekBench by roughly 2%.
 
 ### Windows
 You should have the most recent Intel GPU drivers installed.\
-Copy `nvcuda.dll` to the application directory (the directory where .exe file is) and launch it normally
+Run your application like this:
+```
+<ZLUDA_DIRECTORY>\zluda_with.exe -- <APPLICATION> <APPLICATIONS_ARGUMENTS>
+```
 
 ### Linux
 A very recent version of [compute-runtime](https://github.com/intel/compute-runtime) and [Level Zero loader](https://github.com/oneapi-src/level-zero/releases) is required. At the time of the writing 20.45.18403 is the oldest recommended version.
 Run your application like this:
 ```
-LD_LIBRARY_PATH=<PATH_TO_THE_DIRECTORY_WITH_ZLUDA_PROVIDED_LIBCUDA> <YOUR_APPLICATION>
+LD_LIBRARY_PATH=<ZLUDA_DIRECTORY> <APPLICATION> <APPLICATIONS_ARGUMENTS>
 ```
 
 ## Building

--- a/zluda_dump/Cargo.toml
+++ b/zluda_dump/Cargo.toml
@@ -14,7 +14,7 @@ lz4-sys = "1.9"
 regex = "1.4"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["libloaderapi", "debugapi"] }
+winapi = { version = "0.3", features = ["libloaderapi", "debugapi", "std"] }
 wchar = "0.6"
 detours-sys = { path = "../detours-sys" }
 

--- a/zluda_inject/Cargo.toml
+++ b/zluda_inject/Cargo.toml
@@ -9,5 +9,5 @@ name = "zluda_with"
 path = "src/main.rs"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["jobapi2", "processthreadsapi", "std", "synchapi", "winbase"] }
+winapi = { version = "0.3", features = ["jobapi2", "processthreadsapi", "synchapi", "winbase", "std"] }
 detours-sys = { path = "../detours-sys" }

--- a/zluda_redirect/Cargo.toml
+++ b/zluda_redirect/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 [target.'cfg(windows)'.dependencies]
 detours-sys = { path = "../detours-sys" }
 wchar = "0.6"
-winapi = { version = "0.3", features = ["processthreadsapi", "winbase", "winnt", "winerror", "libloaderapi", "std"] }
+winapi = { version = "0.3", features = ["processthreadsapi", "winbase", "winnt", "winerror", "libloaderapi", "tlhelp32", "std"] }


### PR DESCRIPTION
Basically, what was mentioned in in #35, with the difference that instead of mucking with IAT, we just find nvcuda module in the memory and detour all its symbols to ZLUDA dll.
Overriding IAT is a massive amount of work because `nvcuda.dll` might be an indirect dependency. Though we might be force to go back to overriding IAT at one point - current method is very dodgy.
Currently missing:
- [x] Suspending other threads before performing detours
- [ ] Injecting into child processes