### PR TITLE
Updated Rust version to 1.70.0

### DIFF
--- a/.devcontainer/Dockerfile-common
+++ b/.devcontainer/Dockerfile-common
@@ -33,7 +33,7 @@ RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86
   cuda-nvml-dev-${CUDA_VERSION} \
   libcudnn8-dev
 
-ARG RUST_VERSION=1.66.1
+ARG RUST_VERSION=1.70.0
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=${RUST_VERSION}
 RUN . $HOME/.cargo/env && cargo install bindgen-cli --locked
 


### PR DESCRIPTION
When building the docker container I got the following error:
`error: package lalrpop v0.20.2 cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.66.1`

Updated Rust version in the dockerfile to fix devcontainer build.