### PR TITLE
README.md: improve build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Not supported
 ## Building
 **Warning**: ZLUDA is under heavy development (see news [here](https://vosen.github.io/ZLUDA/blog/zludas-third-life/)). Instructions below might not work.
 
-_Note_: This repo has submodules. Make sure to recurse submodules when cloning this repo, e.g.: `git clone --recursive https://github.com/vosen/ZLUDA.git`
+_Note_: This repo has submodules. Make sure to recurse submodules when cloning this repo, e.g.: `git clone --recursive --depth=1 https://github.com/vosen/ZLUDA.git`
 
  You should have a relatively recent version of Rust installed, then you just do:
 


### PR DESCRIPTION
I bet it's not required to have more than a shallow copy (history depth bigger than 1).