### PR TITLE
Fix build error

### DIFF
--- a/zluda_ml/src/impl.rs
+++ b/zluda_ml/src/impl.rs
@@ -8,7 +8,7 @@ pub(crate) fn unimplemented() -> nvmlReturn_t {
 
 #[cfg(not(debug_assertions))]
 pub(crate) fn unimplemented() -> nvmlReturn_t {
-    nvmlReturn_t::NVML_ERROR_NOT_SUPPORTED
+    nvmlReturn_t::ERROR_NOT_SUPPORTED
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
My build fails with the following error:
```
error[E0599]: no variant or associated item named `NVML_ERROR_NOT_SUPPORTED` found for enum `Result` in the current scope
  --> zluda_ml/src/impl.rs:11:19
   |
11 |     nvmlReturn_t::NVML_ERROR_NOT_SUPPORTED
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^ variant or associated item not found in `Result<(), nvmlError_t>`
   |
help: there is an associated constant `ERROR_NOT_SUPPORTED` with a similar name
   |
11 |     nvmlReturn_t::ERROR_NOT_SUPPORTED
   |                   ~~~~~~~~~~~~~~~~~~~
```
I'm not sure if anyone has run into this yet or if this is an issue on my side, but if not I hope this proposed fix works.