### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Not supported
 * Python 3
 * Rust compiler (recent version)
 * C++ compiler
+* AMD HIP64 library (development package)
 * (Optional, but recommended) [Ninja build system](https://ninja-build.org/)
 
 ### Build steps


### PR DESCRIPTION
List AMD HIP64 library as dependency

On clean Ubuntu 24.04 system I had to install libamdhip64-dev to fix  `/usr/bin/ld: cannot find -lamdhip64: No such file or directory` during build.