### PR TITLE
Explicitly fail compilation on ROCm 6.4

### DIFF
--- a/ext/amd_comgr-sys/build.rs
+++ b/ext/amd_comgr-sys/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), VarError> {
             println!("cargo:rustc-link-search=native=C:\\Windows\\System32");
         };
     } else {
-        println!("cargo:rustc-link-lib=dylib=amd_comgr");
+        println!("cargo:rustc-link-lib=dylib:+verbatim=libamd_comgr.so.2");
         println!("cargo:rustc-link-search=native=/opt/rocm/lib/");
     }
     Ok(())

--- a/ext/hip_runtime-sys/build.rs
+++ b/ext/hip_runtime-sys/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), VarError> {
             println!("cargo:rustc-link-search=native=C:\\Windows\\System32");
         };
     } else {
-        println!("cargo:rustc-link-lib=dylib=amdhip64");
+        println!("cargo:rustc-link-lib=dylib:+verbatim=libamdhip64.so.6");
         println!("cargo:rustc-link-search=native=/opt/rocm/lib/");
     }
     Ok(())


### PR DESCRIPTION
AMD broke comgr ABI in 6.4. This is a temporary solution.