### PR TITLE
Implement cuModuleGetLoadingMode

### DIFF
--- a/zluda/src/impl/mod.rs
+++ b/zluda/src/impl/mod.rs
@@ -1,6 +1,10 @@
 use cuda_types::cuda::*;
 use hip_runtime_sys::*;
-use std::{ffi::CStr, mem::{self, ManuallyDrop, MaybeUninit}, ptr};
+use std::{
+    ffi::CStr,
+    mem::{self, ManuallyDrop, MaybeUninit},
+    ptr,
+};
 
 pub(super) mod context;
 pub(super) mod device;
@@ -131,6 +135,7 @@ from_cuda_nop!(
     cuda_types::cuda::CUdevprop,
     CUdevice_attribute,
     CUdriverProcAddressQueryResult,
+    CUmoduleLoadingMode,
     CUuuid
 );
 from_cuda_transmute!(

--- a/zluda/src/impl/module.rs
+++ b/zluda/src/impl/module.rs
@@ -53,3 +53,8 @@ pub(crate) fn get_function(
 ) -> hipError_t {
     unsafe { hipModuleGetFunction(hfunc, hmod.base, name) }
 }
+
+pub(crate) fn get_loading_mode(mode: &mut cuda_types::cuda::CUmoduleLoadingMode) -> CUresult {
+    *mode = cuda_types::cuda::CUmoduleLoadingMode::CU_MODULE_EAGER_LOADING;
+    Ok(())
+}

--- a/zluda/src/lib.rs
+++ b/zluda/src/lib.rs
@@ -75,6 +75,7 @@ cuda_base::cuda_function_declarations!(
         cuMemsetD32_v2,
         cuMemsetD8_v2,
         cuModuleGetFunction,
+        cuModuleGetLoadingMode,
         cuModuleLoadData,
         cuModuleUnload,
         cuPointerGetAttribute,


### PR DESCRIPTION
ZLUDA does not currently support lazy loading for modules, so this always returns `CU_MODULE_EAGER_LOADING`.