### PR TITLE
Implement `runtime_callback_hooks_fn6`

### DIFF
--- a/dark_api/src/lib.rs
+++ b/dark_api/src/lib.rs
@@ -251,8 +251,8 @@ dark_api! {
     },
     "{A094798C-2E74-2E74-93F2-0800200C0A66}" => TOOLS_RUNTIME_CALLBACK_HOOKS[7] {
         [0] = SIZE_OF,
-        [2] = runtime_callback_hooks_fn2(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> (),
-        [6] = runtime_callback_hooks_fn6(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> ()
+        [2] = get_unknown_buffer1(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> (),
+        [6] = get_unknown_buffer2(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> ()
     },
     "{C693336E-1121-DF11-A8C3-68F355D89593}" => CONTEXT_LOCAL_STORAGE_INTERFACE_V0301[4] {
         [0] = context_local_storage_ctor(

--- a/zluda/src/impl/driver.rs
+++ b/zluda/src/impl/driver.rs
@@ -76,23 +76,25 @@ pub(crate) fn init(flags: ::core::ffi::c_uint) -> CUresult {
     Ok(())
 }
 
-const FN2_BUFFER_SIZE: usize = 1024;
-
-struct Fn2Buffer {
-    buffer: std::cell::UnsafeCell<[u32; FN2_BUFFER_SIZE]>,
+struct UnknownBuffer<const S: usize> {
+    buffer: std::cell::UnsafeCell<[u32; S]>,
 }
 
-impl Fn2Buffer {
+impl<const S: usize> UnknownBuffer<S> {
     const fn new() -> Self {
-        Fn2Buffer {
-            buffer: std::cell::UnsafeCell::new([0; FN2_BUFFER_SIZE]),
+        UnknownBuffer {
+            buffer: std::cell::UnsafeCell::new([0; S]),
         }
+    }
+    const fn len(&self) -> usize {
+        S
     }
 }
 
-unsafe impl Sync for Fn2Buffer {}
+unsafe impl<const S: usize> Sync for UnknownBuffer<S> {}
 
-static FN2_BUFFER: Fn2Buffer = Fn2Buffer::new();
+static UNKNOWN_BUFFER1: UnknownBuffer<1024> = UnknownBuffer::new();
+static UNKNOWN_BUFFER2: UnknownBuffer<14> = UnknownBuffer::new();
 
 struct DarkApi {}
 
@@ -140,19 +142,20 @@ impl ::dark_api::cuda::CudaDarkApi for DarkApi {
         todo!()
     }
 
-    unsafe extern "system" fn runtime_callback_hooks_fn2(
+    unsafe extern "system" fn get_unknown_buffer1(
         ptr: *mut *mut std::ffi::c_void,
         size: *mut usize,
     ) -> () {
-        *ptr = FN2_BUFFER.buffer.get() as *mut std::ffi::c_void;
-        *size = FN2_BUFFER_SIZE;
+        *ptr = UNKNOWN_BUFFER1.buffer.get() as *mut std::ffi::c_void;
+        *size = UNKNOWN_BUFFER1.len();
     }
 
-    unsafe extern "system" fn runtime_callback_hooks_fn6(
+    unsafe extern "system" fn get_unknown_buffer2(
         ptr: *mut *mut std::ffi::c_void,
         size: *mut usize,
     ) -> () {
-        todo!()
+        *ptr = UNKNOWN_BUFFER2.buffer.get() as *mut std::ffi::c_void;
+        *size = UNKNOWN_BUFFER2.len();
     }
 
     unsafe extern "system" fn context_local_storage_ctor(

--- a/zluda_dump/src/lib.rs
+++ b/zluda_dump/src/lib.rs
@@ -401,8 +401,8 @@ impl ::dark_api::cuda::CudaDarkApi for DarkApiDump {
 
     dark_api_fn_redirect_log! {
         TOOLS_RUNTIME_CALLBACK_HOOKS {
-            [2] = runtime_callback_hooks_fn2(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> (),
-            [6] = runtime_callback_hooks_fn6(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> ()
+            [2] = get_unknown_buffer1(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> (),
+            [6] = get_unknown_buffer2(ptr: *mut *mut std::ffi::c_void, size: *mut usize) -> ()
         }
     }
 


### PR DESCRIPTION
This change renames `runtime_callback_hooks_fn2` to `get_unknown_buffer1` and `runtime_callback_hooks_fn6` to `get_unknown_buffer2`, fixes the buffer size for `get_unknown_buffer1`, and implements `get_unknown_buffer2`.