### PR TITLE
Read test files at runtime for development ergonomics

### DIFF
--- a/ptx/Cargo.toml
+++ b/ptx/Cargo.toml
@@ -31,3 +31,6 @@ tempfile = "3"
 paste = "1.0"
 pretty_assertions = "1.4.1"
 libloading = "0.8"
+
+[features]
+ci_build = []

--- a/ptx/src/test/spirv_run/mod.rs
+++ b/ptx/src/test/spirv_run/mod.rs
@@ -20,13 +20,11 @@ macro_rules! read_test_file {
         {
             // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx). 
             let mut path = PathBuf::new();
-            println!("{}", file!());
             path.push(env!("CARGO_MANIFEST_DIR"));
             path.pop();
             path.push(file!());
             path.pop();
             path.push($file);
-            println!("{:?}", path);
             std::fs::read_to_string(path).unwrap()
         }
     };

--- a/ptx/src/test/spirv_run/mod.rs
+++ b/ptx/src/test/spirv_run/mod.rs
@@ -20,11 +20,10 @@ macro_rules! read_test_file {
         {
             // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx). 
             let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-
-            let mut file_dir = PathBuf::from(file!());
-            file_dir.pop();
-
-            path.extend(["..", file_dir.to_str().unwrap(), $file]);
+            path.pop();
+            path.push(file!());
+            path.pop();
+            path.push($file);
             std::fs::read_to_string(path).unwrap()
         }
     };

--- a/ptx/src/test/spirv_run/mod.rs
+++ b/ptx/src/test/spirv_run/mod.rs
@@ -10,38 +10,63 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::fs::{self, File};
 use std::io::Write;
 use std::mem;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::str;
+
+#[cfg(not(feature = "ci_build"))]
+macro_rules! read_test_file {
+    ($file:expr) => {
+        {
+            // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx). 
+            let mut path = PathBuf::new();
+            println!("{}", file!());
+            path.push(env!("CARGO_MANIFEST_DIR"));
+            path.pop();
+            path.push(file!());
+            path.pop();
+            path.push($file);
+            println!("{:?}", path);
+            std::fs::read_to_string(path).unwrap()
+        }
+    };
+}
+
+#[cfg(feature = "ci_build")]
+macro_rules! read_test_file {
+    ($file:expr) => {
+        include_str!($file).to_string()
+    };
+}
 
 macro_rules! test_ptx {
     ($fn_name:ident, $input:expr, $output:expr) => {
         paste::item! {
             #[test]
             fn [<$fn_name _hip>]() -> Result<(), Box<dyn std::error::Error>> {
-                let ptx = include_str!(concat!(stringify!($fn_name), ".ptx"));
+                let ptx = read_test_file!(concat!(stringify!($fn_name), ".ptx"));
                 let input = $input;
                 let mut output = $output;
-                test_hip_assert(stringify!($fn_name), ptx, &input, &mut output)
+                test_hip_assert(stringify!($fn_name), &ptx, &input, &mut output)
             }
         }
 
         paste::item! {
             #[test]
             fn [<$fn_name _cuda>]() -> Result<(), Box<dyn std::error::Error>> {
-                let ptx = include_str!(concat!(stringify!($fn_name), ".ptx"));
+                let ptx = read_test_file!(concat!(stringify!($fn_name), ".ptx"));
                 let input = $input;
                 let mut output = $output;
-                test_cuda_assert(stringify!($fn_name), ptx, &input, &mut output)
+                test_cuda_assert(stringify!($fn_name), &ptx, &input, &mut output)
             }
         }
 
         paste::item! {
             #[test]
             fn [<$fn_name _llvm>]() -> Result<(), Box<dyn std::error::Error>> {
-                let ptx = include_str!(concat!(stringify!($fn_name), ".ptx"));
-                let ll = include_str!(concat!("../ll/", stringify!($fn_name), ".ll")).trim();
-                test_llvm_assert(stringify!($fn_name), ptx, &ll)
+                let ptx = read_test_file!(concat!(stringify!($fn_name), ".ptx"));
+                let ll = read_test_file!(concat!("../ll/", stringify!($fn_name), ".ll"));
+                test_llvm_assert(stringify!($fn_name), &ptx, ll.trim())
             }
         }
     };
@@ -274,15 +299,14 @@ impl<T: Debug> Debug for DisplayError<T> {
 impl<T: Debug> error::Error for DisplayError<T> {}
 
 fn test_hip_assert<
-    'a,
     Input: From<u8> + Debug + Copy + PartialEq,
     Output: From<u8> + Debug + Copy + PartialEq + Default,
 >(
     name: &str,
-    ptx_text: &'a str,
+    ptx_text: &str,
     input: &[Input],
     output: &mut [Output],
-) -> Result<(), Box<dyn error::Error + 'a>> {
+) -> Result<(), Box<dyn error::Error>> {
     let ast = ptx_parser::parse_module_checked(ptx_text).unwrap();
     let llvm_ir = pass::to_llvm_module(ast).unwrap();
     let name = CString::new(name)?;
@@ -292,11 +316,11 @@ fn test_hip_assert<
     Ok(())
 }
 
-fn test_llvm_assert<'a>(
+fn test_llvm_assert(
     name: &str,
-    ptx_text: &'a str,
+    ptx_text: &str,
     expected_ll: &str,
-) -> Result<(), Box<dyn error::Error + 'a>> {
+) -> Result<(), Box<dyn error::Error>> {
     let ast = ptx_parser::parse_module_checked(ptx_text).unwrap();
     let llvm_ir = pass::to_llvm_module(ast).unwrap();
     let actual_ll = llvm_ir.llvm_ir.print_module_to_string();
@@ -310,22 +334,21 @@ fn test_llvm_assert<'a>(
             let mut output_file = File::create(output_file).unwrap();
             output_file.write_all(actual_ll.as_bytes()).unwrap();
         }
-        let comparison = pretty_assertions::StrComparison::new(expected_ll, actual_ll);
+        let comparison = pretty_assertions::StrComparison::new(&expected_ll, &actual_ll);
         panic!("assertion failed: `(left == right)`\n\n{}", comparison);
     }
     Ok(())
 }
 
 fn test_cuda_assert<
-    'a,
     Input: From<u8> + Debug + Copy + PartialEq,
     Output: From<u8> + Debug + Copy + PartialEq + Default,
 >(
     name: &str,
-    ptx_text: &'a str,
+    ptx_text: &str,
     input: &[Input],
     output: &mut [Output],
-) -> Result<(), Box<dyn error::Error + 'a>> {
+) -> Result<(), Box<dyn error::Error>> {
     let name = CString::new(name)?;
     let result = run_cuda(name.as_c_str(), ptx_text, input, output);
     assert_eq!(result.as_slice(), output);

--- a/ptx/src/test/spirv_run/mod.rs
+++ b/ptx/src/test/spirv_run/mod.rs
@@ -19,12 +19,12 @@ macro_rules! read_test_file {
     ($file:expr) => {
         {
             // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx). 
-            let mut path = PathBuf::new();
-            path.push(env!("CARGO_MANIFEST_DIR"));
-            path.pop();
-            path.push(file!());
-            path.pop();
-            path.push($file);
+            let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+            let mut file_dir = PathBuf::from(file!());
+            file_dir.pop();
+
+            path.extend(["..", file_dir.to_str().unwrap(), $file]);
             std::fs::read_to_string(path).unwrap()
         }
     };


### PR DESCRIPTION
Adds the `ptx/ci_build` feature to enable test files to be bundled directly in the executable.