### PR TITLE
Add initialized check to protect zluda from calls during shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
+
+[[package]]
 name = "dynasm"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1773,7 @@ dependencies = [
  "cuda_base",
  "cuda_types",
  "dark_api",
+ "dtor",
  "hip_runtime-sys",
  "lazy_static",
  "lz4-sys",

--- a/zluda/Cargo.toml
+++ b/zluda/Cargo.toml
@@ -22,6 +22,7 @@ lz4-sys = "1.9"
 tempfile = "3"
 paste = "1.0"
 rustc-hash = "1.1"
+dtor = "0.0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["heapapi", "std"] }

--- a/zluda/src/lib.rs
+++ b/zluda/src/lib.rs
@@ -1,4 +1,15 @@
+use cuda_types::cuda::CUerror;
+use std::sync::atomic::{AtomicBool, Ordering};
 pub(crate) mod r#impl;
+
+static INITIALIZED: AtomicBool = AtomicBool::new(true);
+pub(crate) fn initialized() -> bool {
+    INITIALIZED.load(Ordering::SeqCst)
+}
+#[dtor::dtor]
+fn deinitialize() {
+    INITIALIZED.store(false, Ordering::SeqCst);
+}
 
 macro_rules! unimplemented {
     ($($abi:literal fn $fn_name:ident( $($arg_id:ident : $arg_type:ty),* ) -> $ret_type:ty;)*) => {
@@ -20,6 +31,9 @@ macro_rules! implemented {
             #[allow(improper_ctypes)]
             #[allow(improper_ctypes_definitions)]
             pub unsafe extern $abi fn $fn_name ( $( $arg_id : $arg_type),* ) -> $ret_type {
+                if !initialized() {
+                    return Err(CUerror::DEINITIALIZED);
+                }
                 cuda_base::cuda_normalize_fn!( crate::r#impl::$fn_name ) ($(crate::r#impl::FromCuda::from_cuda(&$arg_id)?),*)?;
                 Ok(())
             }
@@ -34,6 +48,9 @@ macro_rules! implemented_in_function {
             #[allow(improper_ctypes)]
             #[allow(improper_ctypes_definitions)]
             pub unsafe extern $abi fn $fn_name ( $( $arg_id : $arg_type),* ) -> $ret_type {
+                if !initialized() {
+                    return Err(CUerror::DEINITIALIZED);
+                }
                 cuda_base::cuda_normalize_fn!( crate::r#impl::function::$fn_name ) ($(crate::r#impl::FromCuda::from_cuda(&$arg_id)?),*)?;
                 Ok(())
             }


### PR DESCRIPTION
The CUDA runtime hooks into the exit handler and makes calls into the CUDA driver during shutdown. If the real driver is shutting down it returns DEINITIALIZED. This change adds the same behavior for ZLUDA, which fixes crashes that occur when, among other things, calls reference unloaded static variables.