### PR TITLE
Fix typo in README.md(self-contained)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you want to contribute a code fix or documentation update feel free to open a
 
 There's no architecture document (yet). Two most important crates in ZLUDA are `ptx` (PTX compiler) and `zluda` (AMD GPU runtime). A good starting point to tinkering the project is to run one of the `ptx` unit tests under a debugger and understand what it is doing. `cargo test -p ptx -- ::add_amdgpu` is a simple test that adds two numbers.
 
-Github issues tagged with ["help wanted"](https://github.com/vosen/ZLUDA/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are tasks that are self-containted. Their level of difficulty varies, they are not always good beginner tasks, but they defined unambiguously.
+Github issues tagged with ["help wanted"](https://github.com/vosen/ZLUDA/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) are tasks that are self-contained. Their level of difficulty varies, they are not always good beginner tasks, but they defined unambiguously.
 
 If you have questions feel free to ask on [#devtalk channel on Discord](https://discord.com/channels/1273316903783497778/1303329281409159270).
 


### PR DESCRIPTION
I just noticed it while reading the README.