### PR TITLE
Add parser support for hyphenated IDs in arguments

### DIFF
--- a/ptx_parser_macros/src/lib.rs
+++ b/ptx_parser_macros/src/lib.rs
@@ -197,7 +197,7 @@ impl SingleOpcodeDefinition {
                 })
             })
             .chain(self.arguments.0.iter().map(|arg| {
-                let name = &arg.ident;
+                let name = &arg.ident.ident();
                 let arg_type = if arg.unified {
                     quote! { (ParsedOperandStr<'input>, bool) }
                 } else if arg.can_be_negated {
@@ -225,7 +225,7 @@ impl SingleOpcodeDefinition {
                 })
             })
             .chain(self.arguments.0.iter().map(|arg| {
-                let name = &arg.ident;
+                let name = &arg.ident.ident();
                 quote! { #name }
             }))
     }
@@ -817,7 +817,7 @@ fn emit_definition_parser(
         let pattern = quote! {
             (#comma, #pre_bracket, #pre_pipe, #can_be_negated, #operand, #post_bracket, #unified)
         };
-        let arg_name = &arg.ident;
+        let arg_name = &arg.ident.ident();
         if arg.unified && arg.can_be_negated {
             panic!("TODO: argument can't be both prefixed by `!` and suffixed by  `.unified`")
         }


### PR DESCRIPTION
The syntax description for [`cp.async`](https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async) has several elements not supported by the current parser. One such element is that the `cp-size` and `src-size` operands have hyphens in their IDs. This PR adds support for these IDs, and translates them as `cp_size` and `src_size`.