### PR TITLE
Silence unused variable warnings

### DIFF
--- a/zluda/src/impl/driver.rs
+++ b/zluda/src/impl/driver.rs
@@ -104,8 +104,8 @@ struct DarkApi {}
 
 impl ::dark_api::cuda::CudaDarkApi for DarkApi {
     unsafe extern "system" fn get_module_from_cubin(
-        module: *mut cuda_types::cuda::CUmodule,
-        fatbinc_wrapper: *const cuda_types::dark_api::FatbincWrapper,
+        _module: *mut cuda_types::cuda::CUmodule,
+        _fatbinc_wrapper: *const cuda_types::dark_api::FatbincWrapper,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
@@ -123,25 +123,25 @@ impl ::dark_api::cuda::CudaDarkApi for DarkApi {
     }
 
     unsafe extern "system" fn get_module_from_cubin_ext1(
-        result: *mut cuda_types::cuda::CUmodule,
-        fatbinc_wrapper: *const cuda_types::dark_api::FatbincWrapper,
-        arg3: *mut std::ffi::c_void,
-        arg4: *mut std::ffi::c_void,
-        arg5: u32,
+        _result: *mut cuda_types::cuda::CUmodule,
+        _fatbinc_wrapper: *const cuda_types::dark_api::FatbincWrapper,
+        _arg3: *mut std::ffi::c_void,
+        _arg4: *mut std::ffi::c_void,
+        _arg5: u32,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
-    unsafe extern "system" fn cudart_interface_fn7(arg1: usize) -> cuda_types::cuda::CUresult {
+    unsafe extern "system" fn cudart_interface_fn7(_arg1: usize) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
     unsafe extern "system" fn get_module_from_cubin_ext2(
-        fatbin_header: *const cuda_types::dark_api::FatbinHeader,
-        result: *mut cuda_types::cuda::CUmodule,
-        arg3: *mut std::ffi::c_void,
-        arg4: *mut std::ffi::c_void,
-        arg5: u32,
+        _fatbin_header: *const cuda_types::dark_api::FatbinHeader,
+        _result: *mut cuda_types::cuda::CUmodule,
+        _arg3: *mut std::ffi::c_void,
+        _arg4: *mut std::ffi::c_void,
+        _arg5: u32,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
@@ -231,40 +231,40 @@ impl ::dark_api::cuda::CudaDarkApi for DarkApi {
     }
 
     unsafe extern "system" fn ctx_create_v2_bypass(
-        pctx: *mut cuda_types::cuda::CUcontext,
-        flags: ::std::os::raw::c_uint,
-        dev: cuda_types::cuda::CUdevice,
+        _pctx: *mut cuda_types::cuda::CUcontext,
+        _flags: ::std::os::raw::c_uint,
+        _dev: cuda_types::cuda::CUdevice,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
     unsafe extern "system" fn heap_alloc(
-        heap_alloc_record_ptr: *mut *const std::ffi::c_void,
-        arg2: usize,
-        arg3: usize,
+        _heap_alloc_record_ptr: *mut *const std::ffi::c_void,
+        _arg2: usize,
+        _arg3: usize,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
     unsafe extern "system" fn heap_free(
-        heap_alloc_record_ptr: *const std::ffi::c_void,
-        arg2: *mut usize,
+        _heap_alloc_record_ptr: *const std::ffi::c_void,
+        _arg2: *mut usize,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
     unsafe extern "system" fn device_get_attribute_ext(
-        dev: cuda_types::cuda::CUdevice,
-        attribute: std::ffi::c_uint,
-        unknown: std::ffi::c_int,
-        result: *mut [usize; 2],
+        _dev: cuda_types::cuda::CUdevice,
+        _attribute: std::ffi::c_uint,
+        _unknown: std::ffi::c_int,
+        _result: *mut [usize; 2],
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
 
     unsafe extern "system" fn device_get_something(
-        result: *mut std::ffi::c_uchar,
-        dev: cuda_types::cuda::CUdevice,
+        _result: *mut std::ffi::c_uchar,
+        _dev: cuda_types::cuda::CUdevice,
     ) -> cuda_types::cuda::CUresult {
         todo!()
     }
@@ -302,9 +302,9 @@ impl ::dark_api::cuda::CudaDarkApi for DarkApi {
     }
 
     unsafe extern "system" fn context_check(
-        ctx_in: cuda_types::cuda::CUcontext,
+        _ctx_in: cuda_types::cuda::CUcontext,
         result1: *mut u32,
-        result2: *mut *const std::ffi::c_void,
+        _result2: *mut *const std::ffi::c_void,
     ) -> cuda_types::cuda::CUresult {
         *result1 = 0;
         CUresult::SUCCESS

--- a/zluda/src/impl/library.rs
+++ b/zluda/src/impl/library.rs
@@ -1,5 +1,3 @@
-use crate::r#impl::driver;
-
 use super::{module, ZludaObject, FromCuda};
 use cuda_types::cuda::*;
 use hip_runtime_sys::*;

--- a/zluda/src/impl/os_unix.rs
+++ b/zluda/src/impl/os_unix.rs
@@ -1,17 +1,3 @@
-use std::ffi::c_void;
-
-pub unsafe fn heap_create() -> *mut c_void {
-    usize::MAX as *mut _
-}
-
-pub unsafe fn heap_alloc(_heap: *mut c_void, _bytes: usize) -> *mut c_void {
-    todo!()
-}
-
-pub unsafe fn heap_free(_heap: *mut c_void, _alloc: *mut c_void) {
-    todo!()
-}
-
 // TODO: remove duplication with zluda_dump
 #[link(name = "pthread")]
 unsafe extern "C" {

--- a/zluda/src/impl/os_win.rs
+++ b/zluda/src/impl/os_win.rs
@@ -1,20 +1,3 @@
-use std::ffi::c_void;
-
-use winapi::um::heapapi::{HeapAlloc, HeapFree};
-use winapi::um::{heapapi::HeapCreate, winnt::HEAP_NO_SERIALIZE};
-
-pub unsafe fn heap_create() -> *mut c_void {
-    HeapCreate(HEAP_NO_SERIALIZE, 0, 0)
-}
-
-pub unsafe fn heap_alloc(heap: *mut c_void, bytes: usize) -> *mut c_void {
-    HeapAlloc(heap, 0, bytes)
-}
-
-pub unsafe fn heap_free(heap: *mut c_void, alloc: *mut c_void) {
-    HeapFree(heap, 0, alloc);
-}
-
 // TODO: remove duplication with zluda_dump
 #[link(name = "kernel32")]
 unsafe extern "system" {


### PR DESCRIPTION
I'd left these in originally because I'd assumed that these functions would need full implementations soon, but they're really annoying. I've fixed all the other compiler warnings as well.