### PR TITLE
Convert CUDA performance lib statuses to Rust return types

### DIFF
--- a/cuda_types/Cargo.toml
+++ b/cuda_types/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 cuda_macros = { path = "../cuda_macros" }
 hip_runtime-sys = { path = "../ext/hip_runtime-sys" }
 bitflags = "2.9.1"
+hipblas-sys = { version = "0.1.0", path = "../ext/hipblas-sys" }

--- a/cuda_types/src/cublas.rs
+++ b/cuda_types/src/cublas.rs
@@ -17,40 +17,6 @@ pub const CUBLAS_VER_MINOR: u32 = 8;
 pub const CUBLAS_VER_PATCH: u32 = 4;
 pub const CUBLAS_VER_BUILD: u32 = 1;
 pub const CUBLAS_VERSION: u32 = 120804;
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_SUCCESS: cublasStatus_t = cublasStatus_t(0);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_NOT_INITIALIZED: cublasStatus_t = cublasStatus_t(1);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_ALLOC_FAILED: cublasStatus_t = cublasStatus_t(3);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_INVALID_VALUE: cublasStatus_t = cublasStatus_t(7);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_ARCH_MISMATCH: cublasStatus_t = cublasStatus_t(8);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_MAPPING_ERROR: cublasStatus_t = cublasStatus_t(11);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_EXECUTION_FAILED: cublasStatus_t = cublasStatus_t(13);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_INTERNAL_ERROR: cublasStatus_t = cublasStatus_t(14);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_NOT_SUPPORTED: cublasStatus_t = cublasStatus_t(15);
-}
-impl cublasStatus_t {
-    pub const CUBLAS_STATUS_LICENSE_ERROR: cublasStatus_t = cublasStatus_t(16);
-}
-#[repr(transparent)]
-#[must_use]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub struct cublasStatus_t(pub ::core::ffi::c_uint);
 impl cublasFillMode_t {
     pub const CUBLAS_FILL_MODE_LOWER: cublasFillMode_t = cublasFillMode_t(0);
 }
@@ -322,3 +288,76 @@ pub type cublasHandle_t = *mut cublasContext;
 pub type cublasLogCallback = ::core::option::Option<
     unsafe extern "C" fn(msg: *const ::core::ffi::c_char),
 >;
+impl cublasError_t {
+    pub const NOT_INITIALIZED: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(1)
+    });
+    pub const ALLOC_FAILED: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(3)
+    });
+    pub const INVALID_VALUE: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(7)
+    });
+    pub const ARCH_MISMATCH: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(8)
+    });
+    pub const MAPPING_ERROR: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(11)
+    });
+    pub const EXECUTION_FAILED: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(13)
+    });
+    pub const INTERNAL_ERROR: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(14)
+    });
+    pub const NOT_SUPPORTED: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(15)
+    });
+    pub const LICENSE_ERROR: cublasError_t = cublasError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(16)
+    });
+}
+#[repr(transparent)]
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq)]
+pub struct cublasError_t(pub ::core::num::NonZeroU32);
+pub trait cublasStatus_tConsts {
+    const SUCCESS: cublasStatus_t = cublasStatus_t::Ok(());
+    const ERROR_NOT_INITIALIZED: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::NOT_INITIALIZED,
+    );
+    const ERROR_ALLOC_FAILED: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::ALLOC_FAILED,
+    );
+    const ERROR_INVALID_VALUE: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::INVALID_VALUE,
+    );
+    const ERROR_ARCH_MISMATCH: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::ARCH_MISMATCH,
+    );
+    const ERROR_MAPPING_ERROR: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::MAPPING_ERROR,
+    );
+    const ERROR_EXECUTION_FAILED: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::EXECUTION_FAILED,
+    );
+    const ERROR_INTERNAL_ERROR: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::INTERNAL_ERROR,
+    );
+    const ERROR_NOT_SUPPORTED: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::NOT_SUPPORTED,
+    );
+    const ERROR_LICENSE_ERROR: cublasStatus_t = cublasStatus_t::Err(
+        cublasError_t::LICENSE_ERROR,
+    );
+}
+impl cublasStatus_tConsts for cublasStatus_t {}
+#[must_use]
+pub type cublasStatus_t = ::core::result::Result<(), cublasError_t>;
+const _: fn() = || {
+    let _ = std::mem::transmute::<cublasStatus_t, u32>;
+};
+impl From<hipblas_sys::hipblasErrorCode_t> for cublasError_t {
+    fn from(error: hipblas_sys::hipblasErrorCode_t) -> Self {
+        Self(error.0)
+    }
+}

--- a/cuda_types/src/cufft.rs
+++ b/cuda_types/src/cufft.rs
@@ -50,62 +50,8 @@ pub struct cudaLibXtDesc_t {
     pub libDescriptor: *mut ::core::ffi::c_void,
 }
 pub type cudaLibXtDesc = cudaLibXtDesc_t;
-impl cufftResult_t {
-    pub const CUFFT_SUCCESS: cufftResult_t = cufftResult_t(0);
-}
-impl cufftResult_t {
-    pub const CUFFT_INVALID_PLAN: cufftResult_t = cufftResult_t(1);
-}
-impl cufftResult_t {
-    pub const CUFFT_ALLOC_FAILED: cufftResult_t = cufftResult_t(2);
-}
-impl cufftResult_t {
-    pub const CUFFT_INVALID_TYPE: cufftResult_t = cufftResult_t(3);
-}
-impl cufftResult_t {
-    pub const CUFFT_INVALID_VALUE: cufftResult_t = cufftResult_t(4);
-}
-impl cufftResult_t {
-    pub const CUFFT_INTERNAL_ERROR: cufftResult_t = cufftResult_t(5);
-}
-impl cufftResult_t {
-    pub const CUFFT_EXEC_FAILED: cufftResult_t = cufftResult_t(6);
-}
-impl cufftResult_t {
-    pub const CUFFT_SETUP_FAILED: cufftResult_t = cufftResult_t(7);
-}
-impl cufftResult_t {
-    pub const CUFFT_INVALID_SIZE: cufftResult_t = cufftResult_t(8);
-}
-impl cufftResult_t {
-    pub const CUFFT_UNALIGNED_DATA: cufftResult_t = cufftResult_t(9);
-}
-impl cufftResult_t {
-    pub const CUFFT_INCOMPLETE_PARAMETER_LIST: cufftResult_t = cufftResult_t(10);
-}
-impl cufftResult_t {
-    pub const CUFFT_INVALID_DEVICE: cufftResult_t = cufftResult_t(11);
-}
-impl cufftResult_t {
-    pub const CUFFT_PARSE_ERROR: cufftResult_t = cufftResult_t(12);
-}
-impl cufftResult_t {
-    pub const CUFFT_NO_WORKSPACE: cufftResult_t = cufftResult_t(13);
-}
-impl cufftResult_t {
-    pub const CUFFT_NOT_IMPLEMENTED: cufftResult_t = cufftResult_t(14);
-}
-impl cufftResult_t {
-    pub const CUFFT_LICENSE_ERROR: cufftResult_t = cufftResult_t(15);
-}
-impl cufftResult_t {
-    pub const CUFFT_NOT_SUPPORTED: cufftResult_t = cufftResult_t(16);
-}
-#[repr(transparent)]
 #[must_use]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub struct cufftResult_t(pub ::core::ffi::c_uint);
-pub use self::cufftResult_t as cufftResult;
+pub type cufftResult_t = ::core::ffi::c_uint;
 pub type cufftReal = f32;
 pub type cufftDoubleReal = f64;
 pub type cufftComplex = super::cuda::cuComplex;
@@ -425,3 +371,97 @@ pub type cufftJITCallbackStoreD = ::core::option::Option<
         sharedPointer: *mut ::core::ffi::c_void,
     ),
 >;
+impl cufftError_t {
+    pub const INVALID_PLAN: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(1)
+    });
+    pub const ALLOC_FAILED: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(2)
+    });
+    pub const INVALID_TYPE: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(3)
+    });
+    pub const INVALID_VALUE: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(4)
+    });
+    pub const INTERNAL_ERROR: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(5)
+    });
+    pub const EXEC_FAILED: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(6)
+    });
+    pub const SETUP_FAILED: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(7)
+    });
+    pub const INVALID_SIZE: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(8)
+    });
+    pub const UNALIGNED_DATA: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(9)
+    });
+    pub const INCOMPLETE_PARAMETER_LIST: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(10)
+    });
+    pub const INVALID_DEVICE: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(11)
+    });
+    pub const PARSE_ERROR: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(12)
+    });
+    pub const NO_WORKSPACE: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(13)
+    });
+    pub const NOT_IMPLEMENTED: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(14)
+    });
+    pub const LICENSE_ERROR: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(15)
+    });
+    pub const NOT_SUPPORTED: cufftError_t = cufftError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(16)
+    });
+}
+#[repr(transparent)]
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq)]
+pub struct cufftError_t(pub ::core::num::NonZeroU32);
+pub trait cufftResultConsts {
+    const SUCCESS: cufftResult = cufftResult::Ok(());
+    const ERROR_INVALID_PLAN: cufftResult = cufftResult::Err(cufftError_t::INVALID_PLAN);
+    const ERROR_ALLOC_FAILED: cufftResult = cufftResult::Err(cufftError_t::ALLOC_FAILED);
+    const ERROR_INVALID_TYPE: cufftResult = cufftResult::Err(cufftError_t::INVALID_TYPE);
+    const ERROR_INVALID_VALUE: cufftResult = cufftResult::Err(
+        cufftError_t::INVALID_VALUE,
+    );
+    const ERROR_INTERNAL_ERROR: cufftResult = cufftResult::Err(
+        cufftError_t::INTERNAL_ERROR,
+    );
+    const ERROR_EXEC_FAILED: cufftResult = cufftResult::Err(cufftError_t::EXEC_FAILED);
+    const ERROR_SETUP_FAILED: cufftResult = cufftResult::Err(cufftError_t::SETUP_FAILED);
+    const ERROR_INVALID_SIZE: cufftResult = cufftResult::Err(cufftError_t::INVALID_SIZE);
+    const ERROR_UNALIGNED_DATA: cufftResult = cufftResult::Err(
+        cufftError_t::UNALIGNED_DATA,
+    );
+    const ERROR_INCOMPLETE_PARAMETER_LIST: cufftResult = cufftResult::Err(
+        cufftError_t::INCOMPLETE_PARAMETER_LIST,
+    );
+    const ERROR_INVALID_DEVICE: cufftResult = cufftResult::Err(
+        cufftError_t::INVALID_DEVICE,
+    );
+    const ERROR_PARSE_ERROR: cufftResult = cufftResult::Err(cufftError_t::PARSE_ERROR);
+    const ERROR_NO_WORKSPACE: cufftResult = cufftResult::Err(cufftError_t::NO_WORKSPACE);
+    const ERROR_NOT_IMPLEMENTED: cufftResult = cufftResult::Err(
+        cufftError_t::NOT_IMPLEMENTED,
+    );
+    const ERROR_LICENSE_ERROR: cufftResult = cufftResult::Err(
+        cufftError_t::LICENSE_ERROR,
+    );
+    const ERROR_NOT_SUPPORTED: cufftResult = cufftResult::Err(
+        cufftError_t::NOT_SUPPORTED,
+    );
+}
+impl cufftResultConsts for cufftResult {}
+#[must_use]
+pub type cufftResult = ::core::result::Result<(), cufftError_t>;
+const _: fn() = || {
+    let _ = std::mem::transmute::<cufftResult, u32>;
+};

--- a/cuda_types/src/cusparse.rs
+++ b/cuda_types/src/cusparse.rs
@@ -85,50 +85,6 @@ pub struct pruneInfo {
     _unused: [u8; 0],
 }
 pub type pruneInfo_t = *mut pruneInfo;
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_SUCCESS: cusparseStatus_t = cusparseStatus_t(0);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_NOT_INITIALIZED: cusparseStatus_t = cusparseStatus_t(1);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_ALLOC_FAILED: cusparseStatus_t = cusparseStatus_t(2);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_INVALID_VALUE: cusparseStatus_t = cusparseStatus_t(3);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_ARCH_MISMATCH: cusparseStatus_t = cusparseStatus_t(4);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_MAPPING_ERROR: cusparseStatus_t = cusparseStatus_t(5);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_EXECUTION_FAILED: cusparseStatus_t = cusparseStatus_t(6);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_INTERNAL_ERROR: cusparseStatus_t = cusparseStatus_t(7);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED: cusparseStatus_t = cusparseStatus_t(
-        8,
-    );
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_ZERO_PIVOT: cusparseStatus_t = cusparseStatus_t(9);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_NOT_SUPPORTED: cusparseStatus_t = cusparseStatus_t(10);
-}
-impl cusparseStatus_t {
-    pub const CUSPARSE_STATUS_INSUFFICIENT_RESOURCES: cusparseStatus_t = cusparseStatus_t(
-        11,
-    );
-}
-#[repr(transparent)]
-#[must_use]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-pub struct cusparseStatus_t(pub ::core::ffi::c_uint);
 impl cusparsePointerMode_t {
     pub const CUSPARSE_POINTER_MODE_HOST: cusparsePointerMode_t = cusparsePointerMode_t(
         0,
@@ -530,3 +486,83 @@ impl cusparseSpMMOpAlg_t {
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct cusparseSpMMOpAlg_t(pub ::core::ffi::c_uint);
+impl cusparseError_t {
+    pub const NOT_INITIALIZED: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(1)
+    });
+    pub const ALLOC_FAILED: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(2)
+    });
+    pub const INVALID_VALUE: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(3)
+    });
+    pub const ARCH_MISMATCH: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(4)
+    });
+    pub const MAPPING_ERROR: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(5)
+    });
+    pub const EXECUTION_FAILED: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(6)
+    });
+    pub const INTERNAL_ERROR: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(7)
+    });
+    pub const MATRIX_TYPE_NOT_SUPPORTED: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(8)
+    });
+    pub const ZERO_PIVOT: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(9)
+    });
+    pub const NOT_SUPPORTED: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(10)
+    });
+    pub const INSUFFICIENT_RESOURCES: cusparseError_t = cusparseError_t(unsafe {
+        ::core::num::NonZeroU32::new_unchecked(11)
+    });
+}
+#[repr(transparent)]
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq)]
+pub struct cusparseError_t(pub ::core::num::NonZeroU32);
+pub trait cusparseStatus_tConsts {
+    const SUCCESS: cusparseStatus_t = cusparseStatus_t::Ok(());
+    const ERROR_NOT_INITIALIZED: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::NOT_INITIALIZED,
+    );
+    const ERROR_ALLOC_FAILED: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::ALLOC_FAILED,
+    );
+    const ERROR_INVALID_VALUE: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::INVALID_VALUE,
+    );
+    const ERROR_ARCH_MISMATCH: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::ARCH_MISMATCH,
+    );
+    const ERROR_MAPPING_ERROR: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::MAPPING_ERROR,
+    );
+    const ERROR_EXECUTION_FAILED: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::EXECUTION_FAILED,
+    );
+    const ERROR_INTERNAL_ERROR: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::INTERNAL_ERROR,
+    );
+    const ERROR_MATRIX_TYPE_NOT_SUPPORTED: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::MATRIX_TYPE_NOT_SUPPORTED,
+    );
+    const ERROR_ZERO_PIVOT: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::ZERO_PIVOT,
+    );
+    const ERROR_NOT_SUPPORTED: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::NOT_SUPPORTED,
+    );
+    const ERROR_INSUFFICIENT_RESOURCES: cusparseStatus_t = cusparseStatus_t::Err(
+        cusparseError_t::INSUFFICIENT_RESOURCES,
+    );
+}
+impl cusparseStatus_tConsts for cusparseStatus_t {}
+#[must_use]
+pub type cusparseStatus_t = ::core::result::Result<(), cusparseError_t>;
+const _: fn() = || {
+    let _ = std::mem::transmute::<cusparseStatus_t, u32>;
+};

--- a/format/src/format_generated_blas.rs
+++ b/format/src/format_generated_blas.rs
@@ -1,48 +1,6 @@
 // Generated automatically by zluda_bindgen
 // DO NOT EDIT MANUALLY
 #![allow(warnings)]
-impl crate::CudaDisplay for cuda_types::cublas::cublasStatus_t {
-    fn write(
-        &self,
-        _fn_name: &'static str,
-        _index: usize,
-        writer: &mut (impl std::io::Write + ?Sized),
-    ) -> std::io::Result<()> {
-        match self {
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_SUCCESS => {
-                writer.write_all(stringify!(CUBLAS_STATUS_SUCCESS).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_NOT_INITIALIZED => {
-                writer.write_all(stringify!(CUBLAS_STATUS_NOT_INITIALIZED).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_ALLOC_FAILED => {
-                writer.write_all(stringify!(CUBLAS_STATUS_ALLOC_FAILED).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_INVALID_VALUE => {
-                writer.write_all(stringify!(CUBLAS_STATUS_INVALID_VALUE).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_ARCH_MISMATCH => {
-                writer.write_all(stringify!(CUBLAS_STATUS_ARCH_MISMATCH).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_MAPPING_ERROR => {
-                writer.write_all(stringify!(CUBLAS_STATUS_MAPPING_ERROR).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_EXECUTION_FAILED => {
-                writer.write_all(stringify!(CUBLAS_STATUS_EXECUTION_FAILED).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_INTERNAL_ERROR => {
-                writer.write_all(stringify!(CUBLAS_STATUS_INTERNAL_ERROR).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_NOT_SUPPORTED => {
-                writer.write_all(stringify!(CUBLAS_STATUS_NOT_SUPPORTED).as_bytes())
-            }
-            &cuda_types::cublas::cublasStatus_t::CUBLAS_STATUS_LICENSE_ERROR => {
-                writer.write_all(stringify!(CUBLAS_STATUS_LICENSE_ERROR).as_bytes())
-            }
-            _ => write!(writer, "{}", self.0),
-        }
-    }
-}
 impl crate::CudaDisplay for cuda_types::cublas::cublasFillMode_t {
     fn write(
         &self,
@@ -30266,4 +30224,30 @@ pub fn write_cublasUint8gemmBias(
     writer.write_all(concat!(stringify!(C_shift), ": ").as_bytes())?;
     crate::CudaDisplay::write(&C_shift, "cublasUint8gemmBias", arg_idx, writer)?;
     writer.write_all(b")")
+}
+impl crate::CudaDisplay for cuda_types::cublas::cublasStatus_t {
+    fn write(
+        &self,
+        _fn_name: &'static str,
+        _index: usize,
+        writer: &mut (impl std::io::Write + ?Sized),
+    ) -> std::io::Result<()> {
+        match self {
+            Ok(()) => writer.write_all(b"CUBLAS_STATUS_SUCCESS"),
+            Err(err) => {
+                match err.0.get() {
+                    1 => writer.write_all("CUBLAS_STATUS_NOT_INITIALIZED".as_bytes()),
+                    3 => writer.write_all("CUBLAS_STATUS_ALLOC_FAILED".as_bytes()),
+                    7 => writer.write_all("CUBLAS_STATUS_INVALID_VALUE".as_bytes()),
+                    8 => writer.write_all("CUBLAS_STATUS_ARCH_MISMATCH".as_bytes()),
+                    11 => writer.write_all("CUBLAS_STATUS_MAPPING_ERROR".as_bytes()),
+                    13 => writer.write_all("CUBLAS_STATUS_EXECUTION_FAILED".as_bytes()),
+                    14 => writer.write_all("CUBLAS_STATUS_INTERNAL_ERROR".as_bytes()),
+                    15 => writer.write_all("CUBLAS_STATUS_NOT_SUPPORTED".as_bytes()),
+                    16 => writer.write_all("CUBLAS_STATUS_LICENSE_ERROR".as_bytes()),
+                    err => write!(writer, "{}", err),
+                }
+            }
+        }
+    }
 }

--- a/format/src/format_generated_fft.rs
+++ b/format/src/format_generated_fft.rs
@@ -61,69 +61,6 @@ impl crate::CudaDisplay for cuda_types::cufft::cudaLibXtDesc_t {
         writer.write_all(b" }")
     }
 }
-impl crate::CudaDisplay for cuda_types::cufft::cufftResult_t {
-    fn write(
-        &self,
-        _fn_name: &'static str,
-        _index: usize,
-        writer: &mut (impl std::io::Write + ?Sized),
-    ) -> std::io::Result<()> {
-        match self {
-            &cuda_types::cufft::cufftResult_t::CUFFT_SUCCESS => {
-                writer.write_all(stringify!(CUFFT_SUCCESS).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INVALID_PLAN => {
-                writer.write_all(stringify!(CUFFT_INVALID_PLAN).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_ALLOC_FAILED => {
-                writer.write_all(stringify!(CUFFT_ALLOC_FAILED).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INVALID_TYPE => {
-                writer.write_all(stringify!(CUFFT_INVALID_TYPE).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INVALID_VALUE => {
-                writer.write_all(stringify!(CUFFT_INVALID_VALUE).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INTERNAL_ERROR => {
-                writer.write_all(stringify!(CUFFT_INTERNAL_ERROR).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_EXEC_FAILED => {
-                writer.write_all(stringify!(CUFFT_EXEC_FAILED).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_SETUP_FAILED => {
-                writer.write_all(stringify!(CUFFT_SETUP_FAILED).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INVALID_SIZE => {
-                writer.write_all(stringify!(CUFFT_INVALID_SIZE).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_UNALIGNED_DATA => {
-                writer.write_all(stringify!(CUFFT_UNALIGNED_DATA).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INCOMPLETE_PARAMETER_LIST => {
-                writer.write_all(stringify!(CUFFT_INCOMPLETE_PARAMETER_LIST).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_INVALID_DEVICE => {
-                writer.write_all(stringify!(CUFFT_INVALID_DEVICE).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_PARSE_ERROR => {
-                writer.write_all(stringify!(CUFFT_PARSE_ERROR).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_NO_WORKSPACE => {
-                writer.write_all(stringify!(CUFFT_NO_WORKSPACE).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_NOT_IMPLEMENTED => {
-                writer.write_all(stringify!(CUFFT_NOT_IMPLEMENTED).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_LICENSE_ERROR => {
-                writer.write_all(stringify!(CUFFT_LICENSE_ERROR).as_bytes())
-            }
-            &cuda_types::cufft::cufftResult_t::CUFFT_NOT_SUPPORTED => {
-                writer.write_all(stringify!(CUFFT_NOT_SUPPORTED).as_bytes())
-            }
-            _ => write!(writer, "{}", self.0),
-        }
-    }
-}
 impl crate::CudaDisplay for cuda_types::cufft::cufftType_t {
     fn write(
         &self,
@@ -2231,4 +2168,37 @@ pub fn write_cufftXtSetWorkAreaPolicy(
     writer.write_all(concat!(stringify!(workSize), ": ").as_bytes())?;
     crate::CudaDisplay::write(&workSize, "cufftXtSetWorkAreaPolicy", arg_idx, writer)?;
     writer.write_all(b")")
+}
+impl crate::CudaDisplay for cuda_types::cufft::cufftResult {
+    fn write(
+        &self,
+        _fn_name: &'static str,
+        _index: usize,
+        writer: &mut (impl std::io::Write + ?Sized),
+    ) -> std::io::Result<()> {
+        match self {
+            Ok(()) => writer.write_all(b"CUFFT_SUCCESS"),
+            Err(err) => {
+                match err.0.get() {
+                    1 => writer.write_all("CUFFT_INVALID_PLAN".as_bytes()),
+                    2 => writer.write_all("CUFFT_ALLOC_FAILED".as_bytes()),
+                    3 => writer.write_all("CUFFT_INVALID_TYPE".as_bytes()),
+                    4 => writer.write_all("CUFFT_INVALID_VALUE".as_bytes()),
+                    5 => writer.write_all("CUFFT_INTERNAL_ERROR".as_bytes()),
+                    6 => writer.write_all("CUFFT_EXEC_FAILED".as_bytes()),
+                    7 => writer.write_all("CUFFT_SETUP_FAILED".as_bytes()),
+                    8 => writer.write_all("CUFFT_INVALID_SIZE".as_bytes()),
+                    9 => writer.write_all("CUFFT_UNALIGNED_DATA".as_bytes()),
+                    10 => writer.write_all("CUFFT_INCOMPLETE_PARAMETER_LIST".as_bytes()),
+                    11 => writer.write_all("CUFFT_INVALID_DEVICE".as_bytes()),
+                    12 => writer.write_all("CUFFT_PARSE_ERROR".as_bytes()),
+                    13 => writer.write_all("CUFFT_NO_WORKSPACE".as_bytes()),
+                    14 => writer.write_all("CUFFT_NOT_IMPLEMENTED".as_bytes()),
+                    15 => writer.write_all("CUFFT_LICENSE_ERROR".as_bytes()),
+                    16 => writer.write_all("CUFFT_NOT_SUPPORTED".as_bytes()),
+                    err => write!(writer, "{}", err),
+                }
+            }
+        }
+    }
 }

--- a/format/src/format_generated_sparse.rs
+++ b/format/src/format_generated_sparse.rs
@@ -155,60 +155,6 @@ impl crate::CudaDisplay for cuda_types::cusparse::pruneInfo_t {
         }
     }
 }
-impl crate::CudaDisplay for cuda_types::cusparse::cusparseStatus_t {
-    fn write(
-        &self,
-        _fn_name: &'static str,
-        _index: usize,
-        writer: &mut (impl std::io::Write + ?Sized),
-    ) -> std::io::Result<()> {
-        match self {
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_SUCCESS => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_SUCCESS).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_NOT_INITIALIZED => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_NOT_INITIALIZED).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_ALLOC_FAILED => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_ALLOC_FAILED).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_INVALID_VALUE => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_INVALID_VALUE).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_ARCH_MISMATCH => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_ARCH_MISMATCH).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_MAPPING_ERROR => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_MAPPING_ERROR).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_EXECUTION_FAILED => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_EXECUTION_FAILED).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_INTERNAL_ERROR => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_INTERNAL_ERROR).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED => {
-                writer
-                    .write_all(
-                        stringify!(CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED).as_bytes(),
-                    )
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_ZERO_PIVOT => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_ZERO_PIVOT).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_NOT_SUPPORTED => {
-                writer.write_all(stringify!(CUSPARSE_STATUS_NOT_SUPPORTED).as_bytes())
-            }
-            &cuda_types::cusparse::cusparseStatus_t::CUSPARSE_STATUS_INSUFFICIENT_RESOURCES => {
-                writer
-                    .write_all(
-                        stringify!(CUSPARSE_STATUS_INSUFFICIENT_RESOURCES).as_bytes(),
-                    )
-            }
-            _ => write!(writer, "{}", self.0),
-        }
-    }
-}
 impl crate::CudaDisplay for cuda_types::cusparse::cusparsePointerMode_t {
     fn write(
         &self,
@@ -31119,4 +31065,42 @@ pub fn write_cusparseSpMMOp_destroyPlan(
     writer.write_all(concat!(stringify!(plan), ": ").as_bytes())?;
     crate::CudaDisplay::write(&plan, "cusparseSpMMOp_destroyPlan", arg_idx, writer)?;
     writer.write_all(b")")
+}
+impl crate::CudaDisplay for cuda_types::cusparse::cusparseStatus_t {
+    fn write(
+        &self,
+        _fn_name: &'static str,
+        _index: usize,
+        writer: &mut (impl std::io::Write + ?Sized),
+    ) -> std::io::Result<()> {
+        match self {
+            Ok(()) => writer.write_all(b"CUSPARSE_STATUS_SUCCESS"),
+            Err(err) => {
+                match err.0.get() {
+                    1 => writer.write_all("CUSPARSE_STATUS_NOT_INITIALIZED".as_bytes()),
+                    2 => writer.write_all("CUSPARSE_STATUS_ALLOC_FAILED".as_bytes()),
+                    3 => writer.write_all("CUSPARSE_STATUS_INVALID_VALUE".as_bytes()),
+                    4 => writer.write_all("CUSPARSE_STATUS_ARCH_MISMATCH".as_bytes()),
+                    5 => writer.write_all("CUSPARSE_STATUS_MAPPING_ERROR".as_bytes()),
+                    6 => writer.write_all("CUSPARSE_STATUS_EXECUTION_FAILED".as_bytes()),
+                    7 => writer.write_all("CUSPARSE_STATUS_INTERNAL_ERROR".as_bytes()),
+                    8 => {
+                        writer
+                            .write_all(
+                                "CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED".as_bytes(),
+                            )
+                    }
+                    9 => writer.write_all("CUSPARSE_STATUS_ZERO_PIVOT".as_bytes()),
+                    10 => writer.write_all("CUSPARSE_STATUS_NOT_SUPPORTED".as_bytes()),
+                    11 => {
+                        writer
+                            .write_all(
+                                "CUSPARSE_STATUS_INSUFFICIENT_RESOURCES".as_bytes(),
+                            )
+                    }
+                    err => write!(writer, "{}", err),
+                }
+            }
+        }
+    }
 }

--- a/zluda_bindgen/src/main.rs
+++ b/zluda_bindgen/src/main.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, quote, ToTokens};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     borrow::Cow, cmp, collections::hash_map, ffi::CString, fs::File, io::Write, iter, mem,
-    path::PathBuf, ptr, str::FromStr,
+    path::PathBuf, ptr, result, str::FromStr,
 };
 use syn::{
     parse_quote, punctuated::Punctuated, visit_mut::VisitMut, Abi, Fields, FieldsUnnamed, FnArg,
@@ -164,7 +164,7 @@ fn generate_cufft(crate_root: &PathBuf) {
         &["..", "cuda_macros", "src", "cufft.rs"],
         &module,
     );
-    let convert_options = ConvertIntoRustResultOptions {
+    let result_options = ConvertIntoRustResultOptions {
         type_: "cufftResult",
         underlying_type: "cufftResult_t",
         new_error_type: "cufftError_t",
@@ -172,13 +172,15 @@ fn generate_cufft(crate_root: &PathBuf) {
         success: ("CUFFT_SUCCESS", "SUCCESS"),
     };
     generate_types_library(
-        Some(convert_options),
+        Some(&result_options),
         Some(LibraryOverride::CuFft),
         &crate_root,
         &["..", "cuda_types", "src", "cufft.rs"],
         &module,
     );
     generate_display_perflib(
+        "cufft",
+        Some(&result_options),
         &crate_root,
         &["..", "format", "src", "format_generated_fft.rs"],
         &["cuda_types", "cufft"],
@@ -228,7 +230,7 @@ fn generate_cusparse(crate_root: &PathBuf) {
         &["..", "cuda_macros", "src", "cusparse.rs"],
         &module,
     );
-    let convert_options = ConvertIntoRustResultOptions {
+    let result_options = ConvertIntoRustResultOptions {
         type_: "cusparseStatus_t",
         underlying_type: "cusparseStatus_t",
         new_error_type: "cusparseError_t",
@@ -236,13 +238,15 @@ fn generate_cusparse(crate_root: &PathBuf) {
         success: ("CUSPARSE_STATUS_SUCCESS", "SUCCESS"),
     };
     generate_types_library(
-        Some(convert_options),
+        Some(&result_options),
         None,
         &crate_root,
         &["..", "cuda_types", "src", "cusparse.rs"],
         &module,
     );
     generate_display_perflib(
+        "cusparse",
+        Some(&result_options),
         &crate_root,
         &["..", "format", "src", "format_generated_sparse.rs"],
         &["cuda_types", "cusparse"],
@@ -263,7 +267,7 @@ fn generate_cudnn(crate_root: &PathBuf) {
         .generate()
         .unwrap()
         .to_string();
-    let convert_options = ConvertIntoRustResultOptions {
+    let result_options = ConvertIntoRustResultOptions {
         type_: "cudnnStatus_t",
         underlying_type: "cudnnStatus_t",
         new_error_type: "cudnnError_",
@@ -271,7 +275,7 @@ fn generate_cudnn(crate_root: &PathBuf) {
         success: ("CUDNN_STATUS_SUCCESS", "SUCCESS"),
     };
     let cudnn9_module: syn::File = syn::parse_str(&cudnn9).unwrap();
-    let cudnn9_types = generate_types_library_impl(Some(convert_options.clone()), &cudnn9_module);
+    let cudnn9_types = generate_types_library_impl(Some(&result_options), &cudnn9_module);
     let mut current_dir = PathBuf::from(file!());
     current_dir.pop();
     let cudnn8 = new_builder()
@@ -289,7 +293,7 @@ fn generate_cudnn(crate_root: &PathBuf) {
         .unwrap()
         .to_string();
     let cudnn8_module: syn::File = syn::parse_str(&cudnn8).unwrap();
-    let cudnn8_types = generate_types_library_impl(Some(convert_options), &cudnn8_module);
+    let cudnn8_types = generate_types_library_impl(Some(&result_options), &cudnn8_module);
     merge_types(
         &crate_root,
         &["..", "cuda_types", "src", "cudnn.rs"],
@@ -311,6 +315,8 @@ fn generate_cudnn(crate_root: &PathBuf) {
         &cudnn9_module,
     );
     generate_display_perflib(
+        "cudnn9",
+        Some(&result_options),
         &crate_root,
         &["..", "format", "src", "format_generated_dnn9.rs"],
         &["cuda_types", "cudnn9"],
@@ -663,7 +669,7 @@ fn generate_cublas(crate_root: &PathBuf) {
         &["..", "cuda_macros", "src", "cublas.rs"],
         &module,
     );
-    let convert_options = ConvertIntoRustResultOptions {
+    let result_options = ConvertIntoRustResultOptions {
         type_: "cublasStatus_t",
         underlying_type: "cublasStatus_t",
         new_error_type: "cublasError_t",
@@ -671,13 +677,15 @@ fn generate_cublas(crate_root: &PathBuf) {
         success: ("CUBLAS_STATUS_SUCCESS", "SUCCESS"),
     };
     generate_types_library(
-        Some(convert_options),
+        Some(&result_options),
         None,
         &crate_root,
         &["..", "cuda_types", "src", "cublas.rs"],
         &module,
     );
     generate_display_perflib(
+        "cublas",
+        Some(&result_options),
         &crate_root,
         &["..", "format", "src", "format_generated_blas.rs"],
         &["cuda_types", "cublas"],
@@ -750,12 +758,16 @@ fn generate_cublaslt(crate_root: &PathBuf) {
         &module_blas,
     );
     generate_display_perflib(
+        "cublaslt",
+        None,
         &crate_root,
         &["..", "format", "src", "format_generated_blaslt.rs"],
         &["cuda_types", "cublaslt"],
         &module_blas,
     );
     generate_display_perflib(
+        "cublaslt",
+        None,
         &crate_root,
         &["..", "format", "src", "format_generated_blaslt_internal.rs"],
         &["cuda_types", "cublaslt"],
@@ -792,12 +804,21 @@ fn generate_cuda(crate_root: &PathBuf) -> Vec<Ident> {
         &["..", "cuda_macros", "src", "cuda.rs"],
         &module,
     ));
+    let result_options = ConvertIntoRustResultOptions {
+        type_: "CUresult",
+        underlying_type: "cudaError_enum",
+        new_error_type: "CUerror",
+        error_prefix: ("CUDA_ERROR_", "ERROR_"),
+        success: ("CUDA_SUCCESS", "SUCCESS"),
+    };
     generate_types_cuda(
+        &result_options,
         &crate_root,
         &["..", "cuda_types", "src", "cuda.rs"],
         &module,
     );
     generate_display_cuda(
+        &result_options,
         &crate_root,
         &["..", "format", "src", "format_generated.rs"],
         &["cuda_types", "cuda"],
@@ -825,7 +846,7 @@ fn generate_ml(crate_root: &PathBuf) {
         &["..", "cuda_macros", "src", "nvml.rs"],
         &module,
     );
-    let convert_options = ConvertIntoRustResultOptions {
+    let result_options = ConvertIntoRustResultOptions {
         type_: "nvmlReturn_t",
         underlying_type: "nvmlReturn_enum",
         new_error_type: "nvmlError_t",
@@ -833,7 +854,7 @@ fn generate_ml(crate_root: &PathBuf) {
         success: ("NVML_SUCCESS", "SUCCESS"),
     };
     generate_types_library(
-        Some(convert_options),
+        Some(&result_options),
         None,
         &crate_root,
         &["..", "cuda_types", "src", "nvml.rs"],
@@ -842,13 +863,13 @@ fn generate_ml(crate_root: &PathBuf) {
 }
 
 fn generate_types_library(
-    convert_options: Option<ConvertIntoRustResultOptions>,
+    result_options: Option<&ConvertIntoRustResultOptions>,
     override_: Option<LibraryOverride>,
     crate_root: &PathBuf,
     path: &[&str],
     module: &syn::File,
 ) {
-    let module = generate_types_library_impl(convert_options, module);
+    let module = generate_types_library_impl(result_options, module);
     let mut output = crate_root.clone();
     output.extend(path);
     let mut text =
@@ -874,7 +895,7 @@ enum LibraryOverride {
 }
 
 fn generate_types_library_impl(
-    convert_options: Option<ConvertIntoRustResultOptions>,
+    result_options: Option<&ConvertIntoRustResultOptions>,
     module: &syn::File,
 ) -> syn::File {
     let known_reexports: Punctuated<syn::Item, syn::parse::Nothing> = parse_quote! {
@@ -894,8 +915,8 @@ fn generate_types_library_impl(
         Item::ForeignMod(_) => None,
         _ => Some(item),
     };
-    let non_fn = if let Some(options) = convert_options {
-        let mut converter = ConvertIntoRustResult::new(options);
+    let non_fn = if let Some(options) = result_options {
+        let mut converter = ConvertIntoRustResult::new(options.clone());
         let mut non_fn = converter
             .convert(module.items.clone())
             .filter_map(remove_functions)
@@ -1033,15 +1054,14 @@ fn generate_functions(
      */
 }
 
-fn generate_types_cuda(output: &PathBuf, path: &[&str], module: &syn::File) {
+fn generate_types_cuda(
+    options: &ConvertIntoRustResultOptions,
+    output: &PathBuf,
+    path: &[&str],
+    module: &syn::File,
+) {
     let mut module = module.clone();
-    let mut converter = ConvertIntoRustResult::new(ConvertIntoRustResultOptions {
-        type_: "CUresult",
-        underlying_type: "cudaError_enum",
-        new_error_type: "CUerror",
-        error_prefix: ("CUDA_ERROR_", "ERROR_"),
-        success: ("CUDA_SUCCESS", "SUCCESS"),
-    });
+    let mut converter = ConvertIntoRustResult::new(options.clone());
     module.items = converter
         .convert(module.items)
         .filter_map(|item| match item {
@@ -1265,6 +1285,7 @@ impl VisitMut for ExplicitReturnType {
 }
 
 fn generate_display_cuda(
+    result_options: &ConvertIntoRustResultOptions,
     output: &PathBuf,
     path: &[&str],
     types_crate: &[&'static str],
@@ -1321,9 +1342,11 @@ fn generate_display_cuda(
     let mut items = module
         .items
         .iter()
-        .filter_map(|i| cuda_derive_display_trait_for_item(types_crate, &mut derive_state, i))
+        .filter_map(|i| {
+            cuda_derive_display_trait_for_item(Some(result_options), types_crate, &mut derive_state, i)
+        })
         .collect::<Vec<_>>();
-    items.push(curesult_display_trait(&derive_state));
+    items.push(result_display_trait(result_options, &derive_state));
     let mut output = output.clone();
     output.extend(path);
     write_rust_to_file(
@@ -1337,6 +1360,8 @@ fn generate_display_cuda(
 }
 
 fn generate_display_perflib(
+    lib: &str,
+    result_options: Option<&ConvertIntoRustResultOptions>,
     output: &PathBuf,
     path: &[&str],
     types_crate: &[&'static str],
@@ -1363,12 +1388,16 @@ fn generate_display_perflib(
         &ignore_functions,
         &count_selectors,
     );
-    let items = module
+    let mut items = module
         .items
         .iter()
-        .filter_map(|i| cuda_derive_display_trait_for_item(types_crate, &mut derive_state, i))
+        .filter_map(|i| {
+            cuda_derive_display_trait_for_item(result_options, types_crate, &mut derive_state, i)
+        })
         .collect::<Vec<_>>();
-    // TODO: derive result display trait (look at curesult_display_trait)
+    if let Some(result_options) = result_options {
+        items.push(result_display_trait(result_options, &derive_state));
+    }
     let mut output = output.clone();
     output.extend(path);
     write_rust_to_file(
@@ -1439,6 +1468,7 @@ impl<'a> DeriveDisplayState<'a> {
 }
 
 fn cuda_derive_display_trait_for_item<'a>(
+    result_options: Option<&ConvertIntoRustResultOptions>,
     path: &[&str],
     state: &mut DeriveDisplayState<'a>,
     item: &'a Item,
@@ -1453,8 +1483,10 @@ fn cuda_derive_display_trait_for_item<'a>(
     };
     match item {
         Item::Const(const_) => {
-            if const_.ty.to_token_stream().to_string() == "cudaError_enum" {
-                state.result_variants.push(const_);
+            if let Some(result_options) = result_options {
+                if const_.ty.to_token_stream().to_string() == result_options.underlying_type {
+                    state.result_variants.push(const_);
+                }
             }
             None
         }
@@ -1657,11 +1689,21 @@ fn fn_arg_name(fn_arg: &FnArg) -> &Box<syn::Pat> {
     name
 }
 
-fn curesult_display_trait(derive_state: &DeriveDisplayState) -> syn::Item {
+fn result_display_trait(
+    result_options: &ConvertIntoRustResultOptions,
+    derive_state: &DeriveDisplayState,
+) -> syn::Item {
+    let path = &derive_state.types_crate;
+
+    let type_ = Ident::new(result_options.type_, Span::call_site());
+
+    let success = result_options.success.0;
+    let success_bstr = syn::LitByteStr::new(success.as_bytes(), Span::call_site());
+
     let errors = derive_state.result_variants.iter().filter_map(|const_| {
-        let prefix = "cudaError_enum_";
+        let prefix = format!("{}_", result_options.underlying_type);
         let text = &const_.ident.to_string()[prefix.len()..];
-        if text == "CUDA_SUCCESS" {
+        if text == success {
             return None;
         }
         let expr = &const_.expr;
@@ -1670,10 +1712,10 @@ fn curesult_display_trait(derive_state: &DeriveDisplayState) -> syn::Item {
         })
     });
     parse_quote! {
-        impl crate::CudaDisplay for cuda_types::cuda::CUresult {
+        impl crate::CudaDisplay for #path::#type_ {
             fn write(&self, _fn_name: &'static str, _index: usize, writer: &mut (impl std::io::Write + ?Sized)) -> std::io::Result<()> {
                 match self {
-                    Ok(()) => writer.write_all(b"CUDA_SUCCESS"),
+                    Ok(()) => writer.write_all(#success_bstr),
                     Err(err) => {
                         match err.0.get() {
                             #(#errors)*

--- a/zluda_bindgen/src/main.rs
+++ b/zluda_bindgen/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
     generate_cublaslt(&crate_root);
     generate_cufft(&crate_root);
     generate_cusparse(&crate_root);
-    // generate_cudnn(&crate_root);
+    generate_cudnn(&crate_root);
 }
 
 fn generate_process_address_table(crate_root: &PathBuf, mut cuda_fns: Vec<Ident>) {
@@ -1125,7 +1125,6 @@ struct ConvertIntoRustResultOptions {
     new_error_type: &'static str,
     error_prefix: (&'static str, &'static str),
     success: (&'static str, &'static str),
-    // TODO: this should no longer be an Option once all hip perf libraries are present
     hip_type: Option<Path>,
 }
 

--- a/zluda_bindgen/src/main.rs
+++ b/zluda_bindgen/src/main.rs
@@ -170,6 +170,7 @@ fn generate_cufft(crate_root: &PathBuf) {
         new_error_type: "cufftError_t",
         error_prefix: ("CUFFT_", "ERROR_"),
         success: ("CUFFT_SUCCESS", "SUCCESS"),
+        hip_type: None,
     };
     generate_types_library(
         Some(&result_options),
@@ -236,6 +237,7 @@ fn generate_cusparse(crate_root: &PathBuf) {
         new_error_type: "cusparseError_t",
         error_prefix: ("CUSPARSE_STATUS_", "ERROR_"),
         success: ("CUSPARSE_STATUS_SUCCESS", "SUCCESS"),
+        hip_type: None,
     };
     generate_types_library(
         Some(&result_options),
@@ -273,6 +275,7 @@ fn generate_cudnn(crate_root: &PathBuf) {
         new_error_type: "cudnnError_",
         error_prefix: ("CUDNN_STATUS_", "ERROR_"),
         success: ("CUDNN_STATUS_SUCCESS", "SUCCESS"),
+        hip_type: None,
     };
     let cudnn9_module: syn::File = syn::parse_str(&cudnn9).unwrap();
     let cudnn9_types = generate_types_library_impl(Some(&result_options), &cudnn9_module);
@@ -675,6 +678,7 @@ fn generate_cublas(crate_root: &PathBuf) {
         new_error_type: "cublasError_t",
         error_prefix: ("CUBLAS_STATUS_", "ERROR_"),
         success: ("CUBLAS_STATUS_SUCCESS", "SUCCESS"),
+        hip_type: Some(syn::parse_str("hipblas_sys::hipblasErrorCode_t").unwrap()),
     };
     generate_types_library(
         Some(&result_options),
@@ -810,6 +814,7 @@ fn generate_cuda(crate_root: &PathBuf) -> Vec<Ident> {
         new_error_type: "CUerror",
         error_prefix: ("CUDA_ERROR_", "ERROR_"),
         success: ("CUDA_SUCCESS", "SUCCESS"),
+        hip_type: Some(syn::parse_str("hip_runtime_sys::hipErrorCode_t").unwrap()),
     };
     generate_types_cuda(
         &result_options,
@@ -852,6 +857,7 @@ fn generate_ml(crate_root: &PathBuf) {
         new_error_type: "nvmlError_t",
         error_prefix: ("NVML_ERROR_", "ERROR_"),
         success: ("NVML_SUCCESS", "SUCCESS"),
+        hip_type: None,
     };
     generate_types_library(
         Some(&result_options),
@@ -961,6 +967,7 @@ fn generate_hip_runtime(output: &PathBuf, path: &[&str]) {
         new_error_type: "hipErrorCode_t",
         error_prefix: ("hipError", "Error"),
         success: ("hipSuccess", "Success"),
+        hip_type: None,
     });
     module.items = converter.convert(module.items).collect::<Vec<Item>>();
     converter.flush(&mut module.items);
@@ -1087,13 +1094,6 @@ fn generate_types_cuda(
         })
         .collect::<Vec<_>>();
     converter.flush(&mut module.items);
-    module.items.push(parse_quote! {
-        impl From<hip_runtime_sys::hipErrorCode_t> for CUerror {
-            fn from(error: hip_runtime_sys::hipErrorCode_t) -> Self {
-                Self(error.0)
-            }
-        }
-    });
     add_send_sync(
         &mut module.items,
         &[
@@ -1125,6 +1125,8 @@ struct ConvertIntoRustResultOptions {
     new_error_type: &'static str,
     error_prefix: (&'static str, &'static str),
     success: (&'static str, &'static str),
+    // TODO: this should no longer be an Option once all hip perf libraries are present
+    hip_type: Option<Path>,
 }
 
 struct ConvertIntoRustResult {
@@ -1211,6 +1213,13 @@ impl ConvertIntoRustResult {
             };
         };
         items.extend(extra_items);
+        if let Some(hip_error_path) = self.options.hip_type {
+            items.push(parse_quote! {impl From<#hip_error_path> for #new_error_type {
+                fn from(error: #hip_error_path) -> Self {
+                    Self(error.0)
+                }
+            }});
+        }
     }
 
     fn get_type(&self, type_: syn::ItemType) -> Option<syn::ItemType> {
@@ -1343,7 +1352,12 @@ fn generate_display_cuda(
         .items
         .iter()
         .filter_map(|i| {
-            cuda_derive_display_trait_for_item(Some(result_options), types_crate, &mut derive_state, i)
+            cuda_derive_display_trait_for_item(
+                Some(result_options),
+                types_crate,
+                &mut derive_state,
+                i,
+            )
         })
         .collect::<Vec<_>>();
     items.push(result_display_trait(result_options, &derive_state));

--- a/zluda_fft/src/impl.rs
+++ b/zluda_fft/src/impl.rs
@@ -1,11 +1,11 @@
-use cuda_types::cufft::cufftResult_t;
+use cuda_types::cufft::*;
 
 #[cfg(debug_assertions)]
-pub(crate) fn unimplemented() -> cufftResult_t {
+pub(crate) fn unimplemented() -> cufftResult {
     unimplemented!()
 }
 
 #[cfg(not(debug_assertions))]
-pub(crate) fn unimplemented() -> cufftResult_t {
-    cufftResult_t::CUFFT_NOT_SUPPORTED
+pub(crate) fn unimplemented() -> cufftResult {
+    cufftResult::ERROR_NOT_SUPPORTED
 }


### PR DESCRIPTION
These changes replicate how the main library is handled. cuDNN still needs to have `zluda_bindgen` run and `zluda_dump_common` updated.