### PR TITLE
Try to make ZLUDA more robust on Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
+
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-Ctarget-feature=+crt-static"]

--- a/llvm_zluda/build.rs
+++ b/llvm_zluda/build.rs
@@ -19,8 +19,8 @@ fn main() {
     cmake
         // It's not like we can do anything about the warnings
         .define("LLVM_ENABLE_WARNINGS", "OFF")
-        // For some reason Rust always links to release MSVCRT
-        .define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreadedDLL")
+        // For some reason Rust always links to release CRT
+        .define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreaded")
         .define("LLVM_ENABLE_TERMINFO", "OFF")
         .define("LLVM_ENABLE_LIBXML2", "OFF")
         .define("LLVM_ENABLE_LIBEDIT", "OFF")

--- a/zluda/Cargo.toml
+++ b/zluda/Cargo.toml
@@ -22,13 +22,13 @@ lz4-sys = "1.9"
 tempfile = "3"
 paste = "1.0"
 rustc-hash = "1.1"
-dtor = "0.0.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["heapapi", "std"] }
 
 [target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
+dtor = "0.0.6"
 
 [package.metadata.zluda]
 linux_symlinks = [

--- a/zluda/src/lib.rs
+++ b/zluda/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 
 #[cfg_attr(windows, path = "os_win.rs")]
+#[cfg_attr(not(windows), path = "os_unix.rs")]
 mod os;
 pub(crate) mod r#impl;
 

--- a/zluda/src/lib.rs
+++ b/zluda/src/lib.rs
@@ -1,12 +1,17 @@
 use cuda_types::cuda::CUerror;
 use std::sync::atomic::{AtomicBool, Ordering};
+
+
+#[cfg_attr(windows, path = "os_win.rs")]
+mod os;
 pub(crate) mod r#impl;
 
 static INITIALIZED: AtomicBool = AtomicBool::new(true);
 pub(crate) fn initialized() -> bool {
     INITIALIZED.load(Ordering::SeqCst)
 }
-#[dtor::dtor]
+
+#[cfg_attr(not(windows), dtor::dtor)]
 fn deinitialize() {
     INITIALIZED.store(false, Ordering::SeqCst);
 }

--- a/zluda/src/os_win.rs
+++ b/zluda/src/os_win.rs
@@ -1,0 +1,13 @@
+use std::ffi::c_void;
+
+const DLL_PROCESS_DETACH: u32 = 0;
+
+#[allow(non_snake_case, unused_variables)]
+#[no_mangle]
+extern "system" fn DllMain(_dll_module: *const c_void, call_reason: u32, _: *const c_void) -> bool {
+    if call_reason == DLL_PROCESS_DETACH {
+        super::deinitialize();
+    }
+
+    true
+}


### PR DESCRIPTION
On my machine ZLUDA seems to segfault when initializing LLVM's C++ statics in Blender. Blender ships with C++ runtime. It seems that compiling C++ runtime statically fixes the issue. Might be actually unrelated.
Additionally, dtor crate on Windows seem to use a slightly dodgy method, so replace it with something more straightforward