### PR TITLE
Implement `cuModuleGetGlobal_v2`

### DIFF
--- a/zluda/src/impl/module.rs
+++ b/zluda/src/impl/module.rs
@@ -103,6 +103,15 @@ pub(crate) fn get_function(
     unsafe { hipModuleGetFunction(hfunc, hmod.base, name) }
 }
 
+pub(crate) fn get_global_v2(
+    dptr: *mut hipDeviceptr_t,
+    bytes: *mut usize,
+    hmod: &Module,
+    name: *const ::core::ffi::c_char,
+) -> hipError_t {
+    unsafe { hipModuleGetGlobal(dptr, bytes, hmod.base, name) }
+}
+
 pub(crate) fn get_loading_mode(mode: &mut cuda_types::cuda::CUmoduleLoadingMode) -> CUresult {
     *mode = cuda_types::cuda::CUmoduleLoadingMode::CU_MODULE_EAGER_LOADING;
     Ok(())

--- a/zluda/src/lib.rs
+++ b/zluda/src/lib.rs
@@ -112,6 +112,7 @@ cuda_macros::cuda_function_declarations!(
             cuMemsetD32_v2,
             cuMemsetD8_v2,
             cuModuleGetFunction,
+            cuModuleGetGlobal_v2,
             cuModuleGetLoadingMode,
             cuModuleLoadData,
             cuModuleUnload,


### PR DESCRIPTION
This is pretty straightforward; I'm just committing this by itself because it's the next function needed by llm.c before the cublas calls.