### PR TITLE
More descriptive syntax errors

### DIFF
--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -1145,7 +1145,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParsedOperand::Reg(id) => write!(f, "{}", id)?,
-            ParsedOperand::RegOffset(id, o) => write!(f, "[{}+{}]", id, o)?,
+            ParsedOperand::RegOffset(id, o) => write!(f, "{}+{}", id, o)?,
             ParsedOperand::Imm(imm) => write!(f, "{}", imm)?,
             ParsedOperand::VecMember(id, idx) => {
                 let suffix = match idx {

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -1138,7 +1138,10 @@ impl<Ident> ParsedOperand<Ident> {
     }
 }
 
-impl<Ident> std::fmt::Display for ParsedOperand<Ident> where Ident: std::fmt::Display {
+impl<Ident> std::fmt::Display for ParsedOperand<Ident>
+where
+    Ident: std::fmt::Display,
+{
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParsedOperand::Reg(id) => write!(f, "{}", id)?,
@@ -1153,7 +1156,7 @@ impl<Ident> std::fmt::Display for ParsedOperand<Ident> where Ident: std::fmt::Di
                     _ => "INVALID",
                 };
                 write!(f, "{}.{}", id, suffix)?
-            },
+            }
             ParsedOperand::VecPack(items) => {
                 f.write_char('{')?;
                 for (idx, item) in items.iter().enumerate() {
@@ -1163,7 +1166,7 @@ impl<Ident> std::fmt::Display for ParsedOperand<Ident> where Ident: std::fmt::Di
                     write!(f, "{}", item)?;
                 }
                 f.write_char('}')?
-            },
+            }
         }
         Ok(())
     }
@@ -1774,9 +1777,14 @@ impl CvtDetails {
             Some((rnd, is_integer)) => (rnd, is_integer),
             None => {
                 if let Some(rnd) = rnd {
-                    errors.push(PtxError::SyntaxError(format!("invalid rounding mode {} for cvt", rnd)));
+                    errors.push(PtxError::SyntaxError(format!(
+                        "invalid rounding mode {} for cvt",
+                        rnd
+                    )));
                 } else {
-                    errors.push(PtxError::SyntaxError(format!("missing rounding mode for cvt")));
+                    errors.push(PtxError::SyntaxError(format!(
+                        "missing rounding mode for cvt"
+                    )));
                 }
                 (RoundingMode::NearestEven, false)
             }
@@ -1799,7 +1807,10 @@ impl CvtDetails {
                 },
                 Ordering::Greater => {
                     if rounding.is_some() {
-                        errors.push(PtxError::SyntaxError("should not have rounding mode when dst is larger than src in cvt".to_string()));
+                        errors.push(PtxError::SyntaxError(
+                            "should not have rounding mode when dst is larger than src in cvt"
+                                .to_string(),
+                        ));
                     }
                     CvtMode::FPExtend {
                         flush_to_zero,
@@ -1859,7 +1870,9 @@ impl CvtDetails {
                 }
             },
             (_, _) => {
-                errors.push(PtxError::SyntaxError("unexpected pairing of dst and src types in cvt".to_string()));
+                errors.push(PtxError::SyntaxError(
+                    "unexpected pairing of dst and src types in cvt".to_string(),
+                ));
                 CvtMode::Bitcast
             }
         };

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -6,7 +6,7 @@ use crate::{
     FunnelShiftMode, Mul24Control, PtxError, PtxParserState, Reduction, ShiftDirection, ShuffleMode,
 };
 use bitflags::bitflags;
-use std::{alloc::Layout, cmp::Ordering, num::NonZeroU8};
+use std::{alloc::Layout, cmp::Ordering, fmt::Write, num::NonZeroU8};
 
 pub enum Statement<P: Operand> {
     Label(P::Ident),
@@ -1138,6 +1138,37 @@ impl<Ident> ParsedOperand<Ident> {
     }
 }
 
+impl<Ident> std::fmt::Display for ParsedOperand<Ident> where Ident: std::fmt::Display {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParsedOperand::Reg(id) => write!(f, "{}", id)?,
+            ParsedOperand::RegOffset(id, o) => write!(f, "[{}+{}]", id, o)?,
+            ParsedOperand::Imm(imm) => write!(f, "{}", imm)?,
+            ParsedOperand::VecMember(id, idx) => {
+                let suffix = match idx {
+                    0 => "x",
+                    1 => "y",
+                    2 => "z",
+                    3 => "w",
+                    _ => "INVALID",
+                };
+                write!(f, "{}.{}", id, suffix)?
+            },
+            ParsedOperand::VecPack(items) => {
+                f.write_char('{')?;
+                for (idx, item) in items.iter().enumerate() {
+                    if idx != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                f.write_char('}')?
+            },
+        }
+        Ok(())
+    }
+}
+
 impl<Ident: Copy> Operand for ParsedOperand<Ident> {
     type Ident = Ident;
 
@@ -1168,6 +1199,18 @@ impl ImmediateValue {
             ImmediateValue::S64(n) => Some(n as u64),
             ImmediateValue::F32(_) | ImmediateValue::F64(_) => None,
         }
+    }
+}
+
+impl std::fmt::Display for ImmediateValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ImmediateValue::U64(n) => write!(f, "{}", n)?,
+            ImmediateValue::S64(n) => write!(f, "{}", n)?,
+            ImmediateValue::F32(n) => write!(f, "{}", n)?,
+            ImmediateValue::F64(n) => write!(f, "{}", n)?,
+        }
+        Ok(())
     }
 }
 
@@ -1730,7 +1773,11 @@ impl CvtDetails {
         let mut unwrap_rounding = || match rounding {
             Some((rnd, is_integer)) => (rnd, is_integer),
             None => {
-                errors.push(PtxError::SyntaxError);
+                if let Some(rnd) = rnd {
+                    errors.push(PtxError::SyntaxError(format!("invalid rounding mode {} for cvt", rnd)));
+                } else {
+                    errors.push(PtxError::SyntaxError(format!("missing rounding mode for cvt")));
+                }
                 (RoundingMode::NearestEven, false)
             }
         };
@@ -1752,7 +1799,7 @@ impl CvtDetails {
                 },
                 Ordering::Greater => {
                     if rounding.is_some() {
-                        errors.push(PtxError::SyntaxError);
+                        errors.push(PtxError::SyntaxError("should not have rounding mode when dst is larger than src in cvt".to_string()));
                     }
                     CvtMode::FPExtend {
                         flush_to_zero,
@@ -1812,7 +1859,7 @@ impl CvtDetails {
                 }
             },
             (_, _) => {
-                errors.push(PtxError::SyntaxError);
+                errors.push(PtxError::SyntaxError("unexpected pairing of dst and src types in cvt".to_string()));
                 CvtMode::Bitcast
             }
         };

--- a/ptx_parser_macros/src/lib.rs
+++ b/ptx_parser_macros/src/lib.rs
@@ -427,11 +427,27 @@ fn emit_enum_types(
             }
             _ => {}
         }
-        let variants = variants.iter().map(|v| v.variant_capitalized());
+        let variants_capitalized = variants.iter().map(|v| v.variant_capitalized());
+        let display_cases = variants.iter().map(|v| {
+            let capitalized = v.variant_capitalized();
+            let v_string = format!("{}", v);
+            quote! {
+                Self::#capitalized => write!(f, #v_string)?
+            }
+        });
         Some(quote! {
             #[derive(Copy, Clone, PartialEq, Eq, Hash)]
             enum #type_ {
-                #(#variants),*
+                #(#variants_capitalized),*
+            }
+
+            impl std::fmt::Display for #type_ {
+                fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    match self {
+                        #(#display_cases),*
+                    }
+                    Ok(())
+                }
             }
         })
     });


### PR DESCRIPTION
Writes more descriptive syntax errors. I'm generating a `Display` implementation for parser enums for use in the errors, and I've implemented it for `ParsedOperand` and `Immediate` as well. This should make it a little easier to inspect the AST state while debugging as well.