### PR TITLE
Add pass test mechanism for insert_implicit_conversions

### DIFF
--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -585,11 +585,7 @@ impl std::fmt::Display for ImplicitConversion {
         write!(
             f,
             "zluda.convert_implicit{}{}{}{}{}",
-            self.kind,
-            self.to_space,
-            self.to_type,
-            self.from_space,
-            self.from_type
+            self.kind, self.to_space, self.to_type, self.from_space, self.from_type
         )
     }
 }

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -257,24 +257,6 @@ enum Statement<I, P: ast::Operand> {
     },
 }
 
-impl<Ident, I, P> std::fmt::Display for Statement<I, P>
-where
-    Ident: std::fmt::Display,
-    I: std::fmt::Display,
-    P: ast::Operand<Ident = Ident>,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Statement::Variable(var) => write!(f, "{}", var)?,
-            Statement::Instruction(instr) => write!(f, "{}", instr)?,
-            Statement::Conversion(conv) => write!(f, "{}", conv)?,
-            _ => todo!(),
-        }
-        write!(f, ";")?;
-        Ok(())
-    }
-}
-
 #[derive(Eq, PartialEq, Clone, Copy)]
 #[cfg_attr(test, derive(Debug))]
 enum ModeRegister {
@@ -602,14 +584,12 @@ impl std::fmt::Display for ImplicitConversion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "zluda.convert_implicit{}{}{}{}{} {}, {}",
+            "zluda.convert_implicit{}{}{}{}{}",
             self.kind,
             self.to_space,
             self.to_type,
             self.from_space,
-            self.from_type,
-            self.dst,
-            self.src
+            self.from_type
         )
     }
 }
@@ -707,26 +687,6 @@ enum Directive2<Instruction, Operand: ast::Operand> {
     Method(Function2<Instruction, Operand>),
 }
 
-impl<Ident, Instruction, Operand> std::fmt::Display for Directive2<Instruction, Operand>
-where
-    Ident: std::fmt::Display,
-    Instruction: std::fmt::Display,
-    Operand: ast::Operand<Ident = Ident>,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Directive2::Variable(linking_directive, variable) => {
-                if !linking_directive.is_empty() {
-                    write!(f, "{} ", linking_directive)?;
-                }
-                write!(f, "{};\n", variable)?;
-            }
-            Directive2::Method(function) => write!(f, "{}", function)?,
-        }
-        Ok(())
-    }
-}
-
 struct Function2<Instruction, Operand: ast::Operand> {
     pub return_arguments: Vec<ast::Variable<Operand::Ident>>,
     pub name: Operand::Ident,
@@ -740,69 +700,6 @@ struct Function2<Instruction, Operand: ast::Operand> {
     flush_to_zero_f16f64: bool,
     rounding_mode_f32: ast::RoundingMode,
     rounding_mode_f16f64: ast::RoundingMode,
-}
-
-impl<Ident, Instruction, Operand> std::fmt::Display for Function2<Instruction, Operand>
-where
-    Ident: std::fmt::Display,
-    Instruction: std::fmt::Display,
-    Operand: ast::Operand<Ident = Ident>,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.import_as.is_some()
-            || self.tuning.len() > 0
-            || self.flush_to_zero_f32
-            || self.flush_to_zero_f16f64
-            || self.rounding_mode_f32 != ast::RoundingMode::NearestEven
-            || self.rounding_mode_f16f64 != ast::RoundingMode::NearestEven
-        {
-            todo!("Figure out some way of representing these in text");
-        }
-
-        if !self.linkage.is_empty() {
-            write!(f, "{} ", self.linkage)?;
-        }
-
-        if self.is_kernel {
-            write!(f, ".entry ")?;
-        } else {
-            write!(f, ".func ")?;
-        }
-
-        if self.return_arguments.len() > 0 {
-            write!(f, "(")?;
-
-            for (idx, arg) in self.return_arguments.iter().enumerate() {
-                if idx != 0 {
-                    write!(f, ", ")?;
-                }
-
-                write!(f, "{}", arg)?;
-            }
-
-            write!(f, ") ")?;
-        }
-
-        write!(f, "{} (\n", self.name)?;
-
-        for arg in self.input_arguments.iter() {
-            write!(f, "    {}\n", arg)?;
-        }
-
-        write!(f, ")")?;
-
-        if let Some(stmts) = &self.body {
-            write!(f, "\n{{\n")?;
-            for stmt in stmts {
-                write!(f, "    {}\n", stmt)?;
-            }
-            write!(f, "}}")?;
-        } else {
-            write!(f, ";")?;
-        }
-
-        Ok(())
-    }
 }
 
 type NormalizedDirective2 = Directive2<

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -590,7 +590,8 @@ impl std::fmt::Display for ImplicitConversion {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, strum_macros::Display)]
+#[strum(serialize_all = "snake_case", prefix = ".")]
 enum ConversionKind {
     Default,
     // zero-extend/chop/bitcast depending on types
@@ -598,19 +599,6 @@ enum ConversionKind {
     BitToPtr,
     PtrToPtr,
     AddressOf,
-}
-
-impl std::fmt::Display for ConversionKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            ConversionKind::Default => ".default",
-            ConversionKind::SignExtend => ".sign_extend",
-            ConversionKind::BitToPtr => ".bit_to_ptr",
-            ConversionKind::PtrToPtr => ".ptr_to_ptr",
-            ConversionKind::AddressOf => ".address_of",
-        };
-        write!(f, "{}", s)
-    }
 }
 
 struct ConstantDefinition {
@@ -1011,4 +999,4 @@ fn scalar_to_ptx_name(this: ast::ScalarType) -> &'static str {
 }
 
 type UnconditionalStatement =
-    Statement<ast::Instruction<ast::ParsedOperand<SpirvWord>>, ast::ParsedOperand<SpirvWord>>;
+     Statement<ast::Instruction<ast::ParsedOperand<SpirvWord>>, ast::ParsedOperand<SpirvWord>>;

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -999,4 +999,4 @@ fn scalar_to_ptx_name(this: ast::ScalarType) -> &'static str {
 }
 
 type UnconditionalStatement =
-     Statement<ast::Instruction<ast::ParsedOperand<SpirvWord>>, ast::ParsedOperand<SpirvWord>>;
+    Statement<ast::Instruction<ast::ParsedOperand<SpirvWord>>, ast::ParsedOperand<SpirvWord>>;

--- a/ptx/src/pass/test/insert_implicit_conversions/default.ptx
+++ b/ptx/src/pass/test/insert_implicit_conversions/default.ptx
@@ -10,13 +10,13 @@
     ret;
 }
 
-// output:
+// %%% output %%%
 
 .func (.reg .b32 %2) %1 (
     .reg .u32 %3
 )
 {
-    zluda.convert_implicit.default.reg.b32.reg.u32 %4, %3;
+    .b32.reg %4 = zluda.convert_implicit.default.reg.b32.reg.u32 %3;
     mov.b32 %2, %4;
     ret;
 }

--- a/ptx/src/pass/test/insert_implicit_conversions/default.ptx
+++ b/ptx/src/pass/test/insert_implicit_conversions/default.ptx
@@ -1,0 +1,22 @@
+.version 6.5
+.target sm_30
+.address_size 64
+
+.func (.reg .b32 output) default (
+    .reg .u32 input
+)
+{
+    mov.b32 output, input;
+    ret;
+}
+
+// output:
+
+.func (.reg .b32 %2) %1 (
+    .reg .u32 %3
+)
+{
+    zluda.convert_implicit.default.reg.b32.reg.u32 %4, %3;
+    mov.b32 %2, %4;
+    ret;
+}

--- a/ptx/src/pass/test/insert_implicit_conversions/mod.rs
+++ b/ptx/src/pass/test/insert_implicit_conversions/mod.rs
@@ -1,5 +1,5 @@
-use crate::pass::*;
 use super::DisplayDirective2Vec;
+use crate::pass::*;
 
 use super::test_pass;
 

--- a/ptx/src/pass/test/insert_implicit_conversions/mod.rs
+++ b/ptx/src/pass/test/insert_implicit_conversions/mod.rs
@@ -1,0 +1,25 @@
+use crate::pass::*;
+use super::DisplayDirective2Vec;
+
+use super::test_pass;
+
+macro_rules! test_insert_implicit_conversions {
+    ($test_name:ident) => {
+        test_pass!(run_insert_implicit_conversions, $test_name);
+    };
+}
+
+fn run_insert_implicit_conversions(
+    ptx: ptx_parser::Module,
+) -> DisplayDirective2Vec<ptx_parser::Instruction<SpirvWord>, SpirvWord> {
+    // We run the minimal number of passes required to produce the input expected by insert_implicit_conversions
+    let mut flat_resolver = GlobalStringIdentResolver2::new(SpirvWord(1));
+    let mut scoped_resolver = ScopedResolver::new(&mut flat_resolver);
+    let directives = normalize_identifiers2::run(&mut scoped_resolver, ptx.directives).unwrap();
+    let directives = normalize_predicates2::run(&mut flat_resolver, directives).unwrap();
+    let directives = expand_operands::run(&mut flat_resolver, directives).unwrap();
+    let directives = insert_implicit_conversions2::run(&mut flat_resolver, directives).unwrap();
+    DisplayDirective2Vec::new(directives)
+}
+
+test_insert_implicit_conversions!(default);

--- a/ptx/src/pass/test/insert_implicit_conversions/mod.rs
+++ b/ptx/src/pass/test/insert_implicit_conversions/mod.rs
@@ -1,5 +1,4 @@
-use super::DisplayDirective2Vec;
-use crate::pass::*;
+use crate::pass::{test::directive2_vec_to_string, *};
 
 use super::test_pass;
 
@@ -9,9 +8,7 @@ macro_rules! test_insert_implicit_conversions {
     };
 }
 
-fn run_insert_implicit_conversions(
-    ptx: ptx_parser::Module,
-) -> DisplayDirective2Vec<ptx_parser::Instruction<SpirvWord>, SpirvWord> {
+fn run_insert_implicit_conversions(ptx: ptx_parser::Module) -> String {
     // We run the minimal number of passes required to produce the input expected by insert_implicit_conversions
     let mut flat_resolver = GlobalStringIdentResolver2::new(SpirvWord(1));
     let mut scoped_resolver = ScopedResolver::new(&mut flat_resolver);
@@ -19,7 +16,7 @@ fn run_insert_implicit_conversions(
     let directives = normalize_predicates2::run(&mut flat_resolver, directives).unwrap();
     let directives = expand_operands::run(&mut flat_resolver, directives).unwrap();
     let directives = insert_implicit_conversions2::run(&mut flat_resolver, directives).unwrap();
-    DisplayDirective2Vec::new(directives)
+    directive2_vec_to_string(&flat_resolver, directives)
 }
 
 test_insert_implicit_conversions!(default);

--- a/ptx/src/pass/test/mod.rs
+++ b/ptx/src/pass/test/mod.rs
@@ -1,0 +1,89 @@
+use std::{
+    env, error,
+    fmt::Display,
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
+
+mod insert_implicit_conversions;
+
+#[macro_export]
+macro_rules! test_pass {
+    ($pass:expr, $test_name:ident) => {
+        paste::item! {
+            #[test]
+            fn [<$test_name>]() -> Result<(), Box<dyn std::error::Error>> {
+                use crate::test::read_test_file;
+                let ptx = read_test_file!(concat!(stringify!($test_name), ".ptx"));
+                let mut parts = ptx.split("// output:");
+                let ptx_in = parts.next().unwrap_or("").trim();
+                let ptx_out = parts.next().unwrap_or("").trim();
+                assert!(parts.next().is_none());
+                crate::pass::test::test_pass_assert(stringify!($test_name), $pass, ptx_in, ptx_out)
+            }
+        }
+    };
+}
+pub(crate) use test_pass;
+
+use super::Directive2;
+
+struct DisplayDirective2Vec<Instruction, Operand: ptx_parser::Operand>(
+    Vec<Directive2<Instruction, Operand>>,
+);
+
+impl<Instruction, Operand: ptx_parser::Operand> DisplayDirective2Vec<Instruction, Operand> {
+    fn new(directives: Vec<Directive2<Instruction, Operand>>) -> Self {
+        Self(directives)
+    }
+}
+
+impl<Ident, Instruction, Operand> std::fmt::Display for DisplayDirective2Vec<Instruction, Operand>
+where
+    Ident: std::fmt::Display,
+    Instruction: std::fmt::Display,
+    Operand: ptx_parser::Operand<Ident = Ident>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for directive in &self.0 {
+            write!(f, "{}", directive)?;
+        }
+        Ok(())
+    }
+}
+
+fn test_pass_assert<F, D>(
+    name: &str,
+    run_pass: F,
+    ptx_in: &str,
+    expected_ptx_out: &str,
+) -> Result<(), Box<dyn error::Error>>
+where
+    F: FnOnce(ptx_parser::Module) -> D,
+    D: Display,
+{
+    let actual_ptx_out = ptx_parser::parse_module_checked(ptx_in).map(|ast| {
+        let result = run_pass(ast);
+        result.to_string()
+    }).unwrap_or("".to_string());
+    compare_ptx(name, ptx_in, &actual_ptx_out, expected_ptx_out);
+    Ok(())
+}
+
+fn compare_ptx(name: &str, ptx_in: &str, actual_ptx_out: &str, expected_ptx_out: &str) {
+    if actual_ptx_out != expected_ptx_out {
+        let output_dir = env::var("TEST_PTX_PASS_FAIL_DIR");
+        if let Ok(output_dir) = output_dir {
+            let output_dir = Path::new(&output_dir);
+            fs::create_dir_all(&output_dir).unwrap();
+            let output_file = output_dir.join(format!("{}.ptx", name));
+            let mut output_file = File::create(output_file).unwrap();
+            output_file.write_all(ptx_in.as_bytes()).unwrap();
+            output_file.write_all(b"\n\n// output:\n\n").unwrap();
+            output_file.write_all(actual_ptx_out.as_bytes()).unwrap();
+        }
+        let comparison = pretty_assertions::StrComparison::new(expected_ptx_out, actual_ptx_out);
+        panic!("assertion failed: `(left == right)`\n\n{}", comparison);
+    }
+}

--- a/ptx/src/pass/test/mod.rs
+++ b/ptx/src/pass/test/mod.rs
@@ -63,10 +63,12 @@ where
     F: FnOnce(ptx_parser::Module) -> D,
     D: Display,
 {
-    let actual_ptx_out = ptx_parser::parse_module_checked(ptx_in).map(|ast| {
-        let result = run_pass(ast);
-        result.to_string()
-    }).unwrap_or("".to_string());
+    let actual_ptx_out = ptx_parser::parse_module_checked(ptx_in)
+        .map(|ast| {
+            let result = run_pass(ast);
+            result.to_string()
+        })
+        .unwrap_or("".to_string());
     compare_ptx(name, ptx_in, &actual_ptx_out, expected_ptx_out);
     Ok(())
 }

--- a/ptx/src/test/mod.rs
+++ b/ptx/src/test/mod.rs
@@ -3,23 +3,28 @@ use ptx_parser as ast;
 
 mod spirv_run;
 
+#[cfg(not(feature = "ci_build"))]
 #[macro_export]
 macro_rules! read_test_file {
     ($file:expr) => {
         {
-            if cfg!(feature = "ci_build") {
-                include_str!($file).to_string()
-            } else {
-                use std::path::PathBuf;
-                // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx).
-                let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-                path.pop();
-                path.push(file!());
-                path.pop();
-                path.push($file);
-                std::fs::read_to_string(path).unwrap()
-            }
+            use std::path::PathBuf;
+            // CARGO_MANIFEST_DIR is the crate directory (ptx), but file! is relative to the workspace root (and therefore also includes ptx).
+            let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+            path.pop();
+            path.push(file!());
+            path.pop();
+            path.push($file);
+            std::fs::read_to_string(path).unwrap()
         }
+    };
+}
+
+#[cfg(feature = "ci_build")]
+#[macro_export]
+macro_rules! read_test_file {
+    ($file:expr) => {
+        include_str!($file).to_string()
     };
 }
 pub(crate) use read_test_file;

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -982,7 +982,7 @@ impl std::fmt::Display for Type {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Type::Scalar(scalar_type) => write!(f, "{}", scalar_type),
-            _ => todo!()
+            _ => todo!(),
         }
     }
 }

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -303,7 +303,8 @@ ptx_parser_macros::generate_instruction_type!(
                     repr: T,
                     space: { data.state_space },
                 }
-            }
+            },
+            display: write!(f, "<TODO:finish ld>")?
         },
         Lg2 {
             type: Type::Scalar(ScalarType::F32),
@@ -356,7 +357,8 @@ ptx_parser_macros::generate_instruction_type!(
             arguments<T>: {
                 dst: T,
                 src: T
-            }
+            },
+            display: write!(f, "mov{}", data.typ)?
         },
         Mul {
             type: { Type::from(data.type_()) },
@@ -457,7 +459,8 @@ ptx_parser_macros::generate_instruction_type!(
             }
         },
         Ret {
-            data: RetData
+            data: RetData,
+            display: write!(f, "ret")?
         },
         Rsqrt {
             type: { Type::from(data.type_) },
@@ -926,6 +929,40 @@ pub struct Variable<ID> {
     pub array_init: Vec<u8>,
 }
 
+impl<ID: std::fmt::Display> std::fmt::Display for Variable<ID> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.state_space)?;
+
+        if let Some(align) = self.align {
+            write!(f, " .align {}", align)?;
+        }
+
+        let (vector_size, scalar_type, array_dims) = match &self.v_type {
+            Type::Scalar(scalar_type) => (None, *scalar_type, &vec![]),
+            Type::Vector(size, scalar_type) => (Some(*size), *scalar_type, &vec![]),
+            Type::Array(vector_size, scalar_type, array_dims) => {
+                (vector_size.map(|s| s.get()), *scalar_type, array_dims)
+            }
+        };
+
+        if let Some(size) = vector_size {
+            write!(f, " .v{}", size)?;
+        }
+
+        write!(f, " {} {}", scalar_type, self.name)?;
+
+        for dim in array_dims {
+            write!(f, "[{}]", dim)?;
+        }
+
+        if self.array_init.len() > 0 {
+            todo!("Need to intepret the array initializer data as the appropriate type");
+        }
+
+        Ok(())
+    }
+}
+
 pub struct PredAt<ID> {
     pub not: bool,
     pub label: ID,
@@ -939,6 +976,15 @@ pub enum Type {
     Vector(u8, ScalarType),
     // .param.b32 foo[4];
     Array(Option<NonZeroU8>, ScalarType, Vec<u32>),
+}
+
+impl std::fmt::Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Scalar(scalar_type) => write!(f, "{}", scalar_type),
+            _ => todo!()
+        }
+    }
 }
 
 impl Type {
@@ -1384,6 +1430,20 @@ bitflags! {
         const EXTERN = 0b001;
         const VISIBLE = 0b10;
         const WEAK = 0b100;
+    }
+}
+
+impl std::fmt::Display for LinkingDirective {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut directives = vec![];
+        if self.contains(LinkingDirective::EXTERN) {
+            directives.push(".extern");
+        } else if self.contains(LinkingDirective::VISIBLE) {
+            directives.push(".visible");
+        } else if self.contains(LinkingDirective::WEAK) {
+            directives.push(".weak");
+        }
+        write!(f, "{}", directives.join(" "))
     }
 }
 

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -956,7 +956,7 @@ impl<ID: std::fmt::Display> std::fmt::Display for Variable<ID> {
         }
 
         if self.array_init.len() > 0 {
-            todo!("Need to intepret the array initializer data as the appropriate type");
+            todo!("Need to interpret the array initializer data as the appropriate type");
         }
 
         Ok(())

--- a/ptx_parser/src/lib.rs
+++ b/ptx_parser/src/lib.rs
@@ -1757,37 +1757,39 @@ derive_parser!(
         DotFile
     }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum StateSpace {
+        #[display(".reg")]
         Reg,
+        #[display("")]
         Generic,
     }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum MemScope { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum ScalarType { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum SetpBoolPostOp { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum AtomSemantics { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum Mul24Control { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum Reduction { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum ShuffleMode { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum ShiftDirection { }
 
-    #[derive(Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Copy, Clone, Display, PartialEq, Eq, Hash)]
     pub enum FunnelShiftMode { }
 
     // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-mov

--- a/ptx_parser_macros/src/lib.rs
+++ b/ptx_parser_macros/src/lib.rs
@@ -416,7 +416,9 @@ fn emit_enum_types(
                     if let Some(enum_) = existing_enums.get_mut(ident) {
                         enum_.variants.extend(variants.into_iter().map(|modifier| {
                             let ident = modifier.variant_capitalized();
+                            let m_string = format!("{}", modifier);
                             let variant: syn::Variant = syn::parse_quote! {
+                                #[display(#m_string)]
                                 #ident
                             };
                             variant
@@ -1050,6 +1052,7 @@ pub fn generate_instruction_type(tokens: proc_macro::TokenStream) -> proc_macro:
     let mut result = proc_macro2::TokenStream::new();
     input.emit_arg_types(&mut result);
     input.emit_instruction_type(&mut result);
+    input.emit_instruction_display(&mut result);
     input.emit_visit(&mut result);
     input.emit_visit_mut(&mut result);
     input.emit_visit_map(&mut result);


### PR DESCRIPTION
Adds the ability to test specific passes, by comparing a text representation of our PTX IR. Because we don't have the ability to parse into any pass-specific IR, this starts from PTX and runs all the passes until the desired pass under test.

The AST description is extended to include a `display` expression that handles displaying the node. The printer will fall back to printing something like `<Abs> %1, %2` if this field is not present. Since these are only being used for tests we can add them as-needed.