### PR TITLE
Add test for conversion from .f16x2 to .b32

### DIFF
--- a/ptx/src/pass/test/insert_implicit_conversions/default_reg_b32_reg_f16x2.ptx
+++ b/ptx/src/pass/test/insert_implicit_conversions/default_reg_b32_reg_f16x2.ptx
@@ -1,0 +1,22 @@
+.version 6.5
+.target sm_30
+.address_size 64
+
+.func (.reg .b32 output) default_reg_b32_reg_f16x2 (
+    .reg .f16x2  input
+)
+{
+    mov.b32 output, input;
+    ret;
+}
+
+// %%% output %%%
+
+.func (.reg .b32 %2) %1 (
+    .reg .f16x2 %3
+)
+{
+    .b32.reg %4 = zluda.convert_implicit.default.reg.b32.reg.f16x2 %3;
+    mov.b32 %2, %4;
+    ret;
+}

--- a/ptx/src/pass/test/insert_implicit_conversions/mod.rs
+++ b/ptx/src/pass/test/insert_implicit_conversions/mod.rs
@@ -20,3 +20,4 @@ fn run_insert_implicit_conversions(ptx: ptx_parser::Module) -> String {
 }
 
 test_insert_implicit_conversions!(default);
+test_insert_implicit_conversions!(default_reg_b32_reg_f16x2);


### PR DESCRIPTION
The implicit conversion pass already handles `f16x2` to `b32`. I've added a test for it and included some fixes for the test code.