### PR TITLE
Try to progress in the face of parsing errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,12 +140,6 @@ dependencies = [
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
@@ -462,7 +456,7 @@ dependencies = [
 name = "dark_api"
 version = "0.0.0"
 dependencies = [
- "bit-vec 0.8.0",
+ "bit-vec",
  "cglue",
  "cuda_types",
  "format",
@@ -2586,7 +2580,7 @@ dependencies = [
 name = "ptx"
 version = "0.0.0"
 dependencies = [
- "bit-vec 0.6.3",
+ "bit-vec",
  "bitflags 1.3.2",
  "comgr",
  "cuda_macros",

--- a/ptx/Cargo.toml
+++ b/ptx/Cargo.toml
@@ -11,7 +11,7 @@ ptx_parser = { path = "../ptx_parser" }
 llvm_zluda = { path = "../llvm_zluda" }
 quick-error = "1.2"
 thiserror = "1.0"
-bit-vec = "0.6"
+bit-vec = "0.8"
 half ="1.6"
 bitflags = "1.2"
 rustc-hash = "2.0.0"

--- a/ptx_parser/Cargo.toml
+++ b/ptx_parser/Cargo.toml
@@ -15,4 +15,4 @@ rustc-hash = "2.0.0"
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "1.0"
 winnow = { version =  "0.6.18" }
-#winnow = { version =  "0.6.18", features = ["debug"] }
+# winnow = { version =  "0.6.18", features = ["debug"] }

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -1492,6 +1492,7 @@ pub enum Directive<'input, O: Operand> {
 pub struct Module<'input> {
     pub version: (u8, u8),
     pub directives: Vec<Directive<'input, ParsedOperand<&'input str>>>,
+    pub invalid_directives: usize,
 }
 
 #[derive(Copy, Clone)]


### PR DESCRIPTION
Previously if we ran into a broken instruction we'd fail whole compilation. This PR changes it so (only in Release mode) we try and progress at all cost. Meaning that if we had trouble parsing an instruction we just remove function form the output and continue.

For some workloads we can still compile a semi-broken, but meaningful subset of a module