### PR TITLE
Remove unnecessary logging of cuLibraryGetModule

### DIFF
--- a/zluda_trace/src/log.rs
+++ b/zluda_trace/src/log.rs
@@ -2,7 +2,6 @@ use super::Settings;
 use crate::FnCallLog;
 use crate::LogEntry;
 use cuda_types::cuda::*;
-use format::CudaDisplay;
 use std::error::Error;
 use std::ffi::c_void;
 use std::ffi::NulError;
@@ -302,7 +301,6 @@ pub(crate) enum ErrorEntry {
         overriden: [u64; 2],
     },
     NullPointer(&'static str),
-    UnknownLibrary(CUlibrary),
     SavedModule(String),
 }
 
@@ -426,12 +424,6 @@ impl Display for ErrorEntry {
             ErrorEntry::NullPointer(type_) => {
                                         write!(f, "Null pointer of type {type_} encountered")
                                     }
-            ErrorEntry::UnknownLibrary(culibrary) => {
-                                        write!(f, "Unknown library: ")?;
-                                        let mut temp_buffer = Vec::new();
-                                        CudaDisplay::write(culibrary, "", 0, &mut temp_buffer).ok();
-                                        f.write_str(&unsafe { String::from_utf8_unchecked(temp_buffer) })
-                            }
             ErrorEntry::SavedModule(file) => write!(f, "Saved module to {file}"),
         }
     }

--- a/zluda_trace/src/trace.rs
+++ b/zluda_trace/src/trace.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use cuda_types::cuda::*;
 use goblin::{elf, elf32, elf64};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use std::{
     ffi::{c_void, CStr, CString},
     fs::{self, File},
@@ -20,23 +20,15 @@ use unwrap_or::unwrap_some_or;
 // * writes out relevant state change and details to disk and log
 pub(crate) struct StateTracker {
     writer: DumpWriter,
-    pub(crate) libraries: FxHashMap<CUlibrary, CodePointer>,
     saved_modules: FxHashSet<CUmodule>,
     library_counter: usize,
     pub(crate) override_cc: Option<(u32, u32)>,
 }
 
-#[derive(Clone, Copy)]
-pub(crate) struct CodePointer(pub *const c_void);
-
-unsafe impl Send for CodePointer {}
-unsafe impl Sync for CodePointer {}
-
 impl StateTracker {
     pub(crate) fn new(settings: &Settings) -> Self {
         StateTracker {
             writer: DumpWriter::new(settings.dump_dir.clone()),
-            libraries: FxHashMap::default(),
             saved_modules: FxHashSet::default(),
             library_counter: 0,
             override_cc: settings.override_cc,


### PR DESCRIPTION
The content of the Module gets logged in `cuLibraryLoadData` anyway, current logging leads to duplicate logs