### PR TITLE
Update LLVM output

### DIFF
--- a/ptx/src/test/ll/bar_red_and_pred.ll
+++ b/ptx/src/test/ll/bar_red_and_pred.ll
@@ -4,116 +4,113 @@ declare hidden i1 @__zluda_ptx_impl_bar_red_or_pred(i32, i1, i1) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @bar_red_and_pred(ptr addrspace(4) byref(i64) %"79", ptr addrspace(4) byref(i64) %"80") #1 {
+define amdgpu_kernel void @bar_red_and_pred(ptr addrspace(4) byref(i64) %"78", ptr addrspace(4) byref(i64) %"79") #1 {
+  %"80" = alloca i64, align 8, addrspace(5)
   %"81" = alloca i64, align 8, addrspace(5)
-  %"82" = alloca i64, align 8, addrspace(5)
+  %"82" = alloca i32, align 4, addrspace(5)
   %"83" = alloca i32, align 4, addrspace(5)
-  %"84" = alloca i32, align 4, addrspace(5)
+  %"84" = alloca i1, align 1, addrspace(5)
   %"85" = alloca i1, align 1, addrspace(5)
-  %"86" = alloca i1, align 1, addrspace(5)
-  %"87" = alloca i32, align 4, addrspace(5)
+  %"86" = alloca i32, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"76"
 
 "76":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"80", align 8
-  store i64 %2, ptr addrspace(5) %"81", align 8
+  %2 = load i64, ptr addrspace(4) %"79", align 8
+  store i64 %2, ptr addrspace(5) %"80", align 8
   %"50" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"77"
-
-"77":                                             ; preds = %"76"
-  store i32 %"50", ptr addrspace(5) %"83", align 4
-  %3 = load i32, ptr addrspace(5) %"83", align 4
-  %"90" = urem i32 %3, 2
-  store i32 %"90", ptr addrspace(5) %"84", align 4
-  %4 = load i32, ptr addrspace(5) %"84", align 4
+  store i32 %"50", ptr addrspace(5) %"82", align 4
+  %3 = load i32, ptr addrspace(5) %"82", align 4
+  %"89" = urem i32 %3, 2
+  store i32 %"89", ptr addrspace(5) %"83", align 4
+  %4 = load i32, ptr addrspace(5) %"83", align 4
   %5 = icmp eq i32 %4, 0
-  store i1 %5, ptr addrspace(5) %"86", align 1
-  store i32 0, ptr addrspace(5) %"87", align 4
-  %6 = load i1, ptr addrspace(5) %"86", align 1
-  %"95" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %6, i1 false)
-  store i1 %"95", ptr addrspace(5) %"85", align 1
-  %7 = load i1, ptr addrspace(5) %"85", align 1
+  store i1 %5, ptr addrspace(5) %"85", align 1
+  store i32 0, ptr addrspace(5) %"86", align 4
+  %6 = load i1, ptr addrspace(5) %"85", align 1
+  %"94" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %6, i1 false)
+  store i1 %"94", ptr addrspace(5) %"84", align 1
+  %7 = load i1, ptr addrspace(5) %"84", align 1
   br i1 %7, label %"19", label %"20"
 
-"19":                                             ; preds = %"77"
-  %8 = load i32, ptr addrspace(5) %"87", align 4
-  %"98" = add i32 %8, 1
-  store i32 %"98", ptr addrspace(5) %"87", align 4
+"19":                                             ; preds = %"76"
+  %8 = load i32, ptr addrspace(5) %"86", align 4
+  %"97" = add i32 %8, 1
+  store i32 %"97", ptr addrspace(5) %"86", align 4
   br label %"20"
 
-"20":                                             ; preds = %"19", %"77"
-  %9 = load i1, ptr addrspace(5) %"86", align 1
-  %"100" = call i1 @__zluda_ptx_impl_bar_red_or_pred(i32 1, i1 %9, i1 false)
-  store i1 %"100", ptr addrspace(5) %"85", align 1
-  %10 = load i1, ptr addrspace(5) %"85", align 1
+"20":                                             ; preds = %"19", %"76"
+  %9 = load i1, ptr addrspace(5) %"85", align 1
+  %"99" = call i1 @__zluda_ptx_impl_bar_red_or_pred(i32 1, i1 %9, i1 false)
+  store i1 %"99", ptr addrspace(5) %"84", align 1
+  %10 = load i1, ptr addrspace(5) %"84", align 1
   br i1 %10, label %"21", label %"22"
 
 "21":                                             ; preds = %"20"
-  %11 = load i32, ptr addrspace(5) %"87", align 4
-  %"103" = add i32 %11, 1
-  store i32 %"103", ptr addrspace(5) %"87", align 4
+  %11 = load i32, ptr addrspace(5) %"86", align 4
+  %"102" = add i32 %11, 1
+  store i32 %"102", ptr addrspace(5) %"86", align 4
   br label %"22"
 
 "22":                                             ; preds = %"21", %"20"
-  store i1 true, ptr addrspace(5) %"86", align 1
-  %12 = load i1, ptr addrspace(5) %"86", align 1
-  %"106" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %12, i1 false)
-  store i1 %"106", ptr addrspace(5) %"85", align 1
-  %13 = load i1, ptr addrspace(5) %"85", align 1
+  store i1 true, ptr addrspace(5) %"85", align 1
+  %12 = load i1, ptr addrspace(5) %"85", align 1
+  %"105" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %12, i1 false)
+  store i1 %"105", ptr addrspace(5) %"84", align 1
+  %13 = load i1, ptr addrspace(5) %"84", align 1
   br i1 %13, label %"23", label %"24"
 
 "23":                                             ; preds = %"22"
-  %14 = load i32, ptr addrspace(5) %"87", align 4
-  %"109" = add i32 %14, 1
-  store i32 %"109", ptr addrspace(5) %"87", align 4
+  %14 = load i32, ptr addrspace(5) %"86", align 4
+  %"108" = add i32 %14, 1
+  store i32 %"108", ptr addrspace(5) %"86", align 4
   br label %"24"
 
 "24":                                             ; preds = %"23", %"22"
-  store i1 false, ptr addrspace(5) %"86", align 1
-  %15 = load i1, ptr addrspace(5) %"86", align 1
-  %"112" = call i1 @__zluda_ptx_impl_bar_red_or_pred(i32 1, i1 %15, i1 false)
-  store i1 %"112", ptr addrspace(5) %"85", align 1
-  %16 = load i1, ptr addrspace(5) %"85", align 1
+  store i1 false, ptr addrspace(5) %"85", align 1
+  %15 = load i1, ptr addrspace(5) %"85", align 1
+  %"111" = call i1 @__zluda_ptx_impl_bar_red_or_pred(i32 1, i1 %15, i1 false)
+  store i1 %"111", ptr addrspace(5) %"84", align 1
+  %16 = load i1, ptr addrspace(5) %"84", align 1
   br i1 %16, label %"25", label %"26"
 
 "25":                                             ; preds = %"24"
-  %17 = load i32, ptr addrspace(5) %"87", align 4
-  %"115" = add i32 %17, 1
-  store i32 %"115", ptr addrspace(5) %"87", align 4
+  %17 = load i32, ptr addrspace(5) %"86", align 4
+  %"114" = add i32 %17, 1
+  store i32 %"114", ptr addrspace(5) %"86", align 4
   br label %"26"
 
 "26":                                             ; preds = %"25", %"24"
-  store i1 true, ptr addrspace(5) %"86", align 1
-  %18 = load i1, ptr addrspace(5) %"86", align 1
-  %"118" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %18, i1 true)
-  store i1 %"118", ptr addrspace(5) %"85", align 1
-  %19 = load i1, ptr addrspace(5) %"85", align 1
+  store i1 true, ptr addrspace(5) %"85", align 1
+  %18 = load i1, ptr addrspace(5) %"85", align 1
+  %"117" = call i1 @__zluda_ptx_impl_bar_red_and_pred(i32 1, i1 %18, i1 true)
+  store i1 %"117", ptr addrspace(5) %"84", align 1
+  %19 = load i1, ptr addrspace(5) %"84", align 1
   br i1 %19, label %"27", label %"28"
 
 "27":                                             ; preds = %"26"
-  %20 = load i32, ptr addrspace(5) %"87", align 4
-  %"121" = add i32 %20, 1
-  store i32 %"121", ptr addrspace(5) %"87", align 4
+  %20 = load i32, ptr addrspace(5) %"86", align 4
+  %"120" = add i32 %20, 1
+  store i32 %"120", ptr addrspace(5) %"86", align 4
   br label %"28"
 
 "28":                                             ; preds = %"27", %"26"
-  %21 = load i32, ptr addrspace(5) %"83", align 4
-  %"123" = zext i32 %21 to i64
-  store i64 %"123", ptr addrspace(5) %"82", align 8
-  %22 = load i64, ptr addrspace(5) %"82", align 8
-  %"125" = mul i64 %22, 4
-  store i64 %"125", ptr addrspace(5) %"82", align 8
+  %21 = load i32, ptr addrspace(5) %"82", align 4
+  %22 = zext i32 %21 to i64
+  store i64 %22, ptr addrspace(5) %"81", align 8
   %23 = load i64, ptr addrspace(5) %"81", align 8
-  %24 = load i64, ptr addrspace(5) %"82", align 8
-  %"127" = add i64 %23, %24
-  store i64 %"127", ptr addrspace(5) %"81", align 8
+  %"124" = mul i64 %23, 4
+  store i64 %"124", ptr addrspace(5) %"81", align 8
+  %24 = load i64, ptr addrspace(5) %"80", align 8
   %25 = load i64, ptr addrspace(5) %"81", align 8
-  %26 = load i32, ptr addrspace(5) %"87", align 4
-  %"132" = inttoptr i64 %25 to ptr
-  store i32 %26, ptr %"132", align 4
+  %"126" = add i64 %24, %25
+  store i64 %"126", ptr addrspace(5) %"80", align 8
+  %26 = load i64, ptr addrspace(5) %"80", align 8
+  %27 = load i32, ptr addrspace(5) %"86", align 4
+  %"131" = inttoptr i64 %26 to ptr
+  store i32 %27, ptr %"131", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/cvt_f16x2_f32.ll
+++ b/ptx/src/test/ll/cvt_f16x2_f32.ll
@@ -30,9 +30,9 @@ define amdgpu_kernel void @cvt_f16x2_f32(ptr addrspace(4) byref(i64) %"40", ptr 
   %"62" = bitcast i32 %8 to float
   %"63" = bitcast i32 %9 to float
   %10 = fptrunc float %"62" to half
-  %11 = insertelement <2 x half> poison, half %10, i32 1
-  %12 = fptrunc float %"63" to half
-  %"53" = insertelement <2 x half> %11, half %12, i32 0
+  %11 = fptrunc float %"63" to half
+  %12 = insertelement <2 x half> poison, half %10, i32 1
+  %"53" = insertelement <2 x half> %12, half %11, i32 0
   store <2 x half> %"53", ptr addrspace(5) %"46", align 4
   %13 = load i64, ptr addrspace(5) %"43", align 8
   %14 = load <2 x half>, ptr addrspace(5) %"46", align 4

--- a/ptx/src/test/ll/cvt_f64_f32.ll
+++ b/ptx/src/test/ll/cvt_f64_f32.ll
@@ -18,12 +18,12 @@ define amdgpu_kernel void @cvt_f64_f32(ptr addrspace(4) byref(i64) %"37", ptr ad
   %5 = load float, ptr addrspace(1) %"51", align 4
   store float %5, ptr addrspace(5) %"41", align 4
   %6 = load float, ptr addrspace(5) %"41", align 4
-  %"47" = fpext float %6 to double
-  store double %"47", ptr addrspace(5) %"42", align 8
-  %7 = load i64, ptr addrspace(5) %"40", align 8
-  %8 = load double, ptr addrspace(5) %"42", align 8
-  %"52" = inttoptr i64 %7 to ptr
-  store double %8, ptr %"52", align 8
+  %7 = fpext float %6 to double
+  store double %7, ptr addrspace(5) %"42", align 8
+  %8 = load i64, ptr addrspace(5) %"40", align 8
+  %9 = load double, ptr addrspace(5) %"42", align 8
+  %"52" = inttoptr i64 %8 to ptr
+  store double %9, ptr %"52", align 8
   ret void
 }
 

--- a/ptx/src/test/ll/cvt_rn_bf16x2_f32.ll
+++ b/ptx/src/test/ll/cvt_rn_bf16x2_f32.ll
@@ -26,9 +26,9 @@ define amdgpu_kernel void @cvt_rn_bf16x2_f32(ptr addrspace(4) byref(i64) %"40", 
   %8 = load float, ptr addrspace(5) %"44", align 4
   %9 = load float, ptr addrspace(5) %"45", align 4
   %10 = fptrunc float %8 to bfloat
-  %11 = insertelement <2 x bfloat> poison, bfloat %10, i32 1
-  %12 = fptrunc float %9 to bfloat
-  %"60" = insertelement <2 x bfloat> %11, bfloat %12, i32 0
+  %11 = fptrunc float %9 to bfloat
+  %12 = insertelement <2 x bfloat> poison, bfloat %10, i32 1
+  %"60" = insertelement <2 x bfloat> %12, bfloat %11, i32 0
   %"53" = bitcast <2 x bfloat> %"60" to i32
   store i32 %"53", ptr addrspace(5) %"46", align 4
   %13 = load i64, ptr addrspace(5) %"43", align 8

--- a/ptx/src/test/ll/cvt_rn_f16x2_e4m3x2.ll
+++ b/ptx/src/test/ll/cvt_rn_f16x2_e4m3x2.ll
@@ -21,13 +21,13 @@ define amdgpu_kernel void @cvt_rn_f16x2_e4m3x2(ptr addrspace(4) byref(i64) %"37"
   store i16 %5, ptr addrspace(5) %"41", align 2
   %6 = load i16, ptr addrspace(5) %"41", align 2
   %"55" = call i32 @__zluda_ptx_impl_cvt_rn_f16x2_e4m3x2(i16 %6)
-  %"52" = bitcast i32 %"55" to <2 x half>
-  %"47" = bitcast <2 x half> %"52" to i32
+  %7 = bitcast i32 %"55" to <2 x half>
+  %"47" = bitcast <2 x half> %7 to i32
   store i32 %"47", ptr addrspace(5) %"42", align 4
-  %7 = load i64, ptr addrspace(5) %"40", align 8
-  %8 = load i32, ptr addrspace(5) %"42", align 4
-  %"54" = inttoptr i64 %7 to ptr
-  store i32 %8, ptr %"54", align 4
+  %8 = load i64, ptr addrspace(5) %"40", align 8
+  %9 = load i32, ptr addrspace(5) %"42", align 4
+  %"54" = inttoptr i64 %8 to ptr
+  store i32 %9, ptr %"54", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/cvt_rn_f16x2_e5m2x2.ll
+++ b/ptx/src/test/ll/cvt_rn_f16x2_e5m2x2.ll
@@ -21,13 +21,13 @@ define amdgpu_kernel void @cvt_rn_f16x2_e5m2x2(ptr addrspace(4) byref(i64) %"37"
   store i16 %5, ptr addrspace(5) %"41", align 2
   %6 = load i16, ptr addrspace(5) %"41", align 2
   %"55" = call i32 @__zluda_ptx_impl_cvt_rn_f16x2_e5m2x2(i16 %6)
-  %"52" = bitcast i32 %"55" to <2 x half>
-  %"47" = bitcast <2 x half> %"52" to i32
+  %7 = bitcast i32 %"55" to <2 x half>
+  %"47" = bitcast <2 x half> %7 to i32
   store i32 %"47", ptr addrspace(5) %"42", align 4
-  %7 = load i64, ptr addrspace(5) %"40", align 8
-  %8 = load i32, ptr addrspace(5) %"42", align 4
-  %"54" = inttoptr i64 %7 to ptr
-  store i32 %8, ptr %"54", align 4
+  %8 = load i64, ptr addrspace(5) %"40", align 8
+  %9 = load i32, ptr addrspace(5) %"42", align 4
+  %"54" = inttoptr i64 %8 to ptr
+  store i32 %9, ptr %"54", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/cvt_s16_s8.ll
+++ b/ptx/src/test/ll/cvt_s16_s8.ll
@@ -19,13 +19,13 @@ define amdgpu_kernel void @cvt_s16_s8(ptr addrspace(4) byref(i64) %"37", ptr add
   store i32 %5, ptr addrspace(5) %"42", align 4
   %6 = load i32, ptr addrspace(5) %"42", align 4
   %7 = trunc i32 %6 to i8
-  %"52" = sext i8 %7 to i16
-  %"47" = sext i16 %"52" to i32
+  %8 = sext i8 %7 to i16
+  %"47" = sext i16 %8 to i32
   store i32 %"47", ptr addrspace(5) %"41", align 4
-  %8 = load i64, ptr addrspace(5) %"40", align 8
-  %9 = load i32, ptr addrspace(5) %"41", align 4
-  %"54" = inttoptr i64 %8 to ptr
-  store i32 %9, ptr %"54", align 4
+  %9 = load i64, ptr addrspace(5) %"40", align 8
+  %10 = load i32, ptr addrspace(5) %"41", align 4
+  %"54" = inttoptr i64 %9 to ptr
+  store i32 %10, ptr %"54", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/cvt_s64_s32.ll
+++ b/ptx/src/test/ll/cvt_s64_s32.ll
@@ -18,12 +18,12 @@ define amdgpu_kernel void @cvt_s64_s32(ptr addrspace(4) byref(i64) %"37", ptr ad
   %5 = load i32, ptr %"52", align 4
   store i32 %5, ptr addrspace(5) %"41", align 4
   %6 = load i32, ptr addrspace(5) %"41", align 4
-  %"47" = sext i32 %6 to i64
-  store i64 %"47", ptr addrspace(5) %"42", align 8
-  %7 = load i64, ptr addrspace(5) %"40", align 8
-  %8 = load i64, ptr addrspace(5) %"42", align 8
-  %"53" = inttoptr i64 %7 to ptr
-  store i64 %8, ptr %"53", align 8
+  %7 = sext i32 %6 to i64
+  store i64 %7, ptr addrspace(5) %"42", align 8
+  %8 = load i64, ptr addrspace(5) %"40", align 8
+  %9 = load i64, ptr addrspace(5) %"42", align 8
+  %"53" = inttoptr i64 %8 to ptr
+  store i64 %9, ptr %"53", align 8
   ret void
 }
 

--- a/ptx/src/test/ll/div_ftz.ll
+++ b/ptx/src/test/ll/div_ftz.ll
@@ -4,64 +4,55 @@ declare hidden %struct.f32.f32.f32.i8 @__zluda_ptx_impl_div_f32_part1(float, flo
 
 declare hidden float @__zluda_ptx_impl_div_f32_part2(float, float, float, float, float, i8) #0
 
-define amdgpu_kernel void @div_ftz(ptr addrspace(4) byref(i64) %"69", ptr addrspace(4) byref(i64) %"70") #1 {
-  %"71" = alloca i64, align 8, addrspace(5)
-  %"72" = alloca i64, align 8, addrspace(5)
-  %"73" = alloca float, align 4, addrspace(5)
-  %"74" = alloca float, align 4, addrspace(5)
-  %"75" = alloca float, align 4, addrspace(5)
+define amdgpu_kernel void @div_ftz(ptr addrspace(4) byref(i64) %"66", ptr addrspace(4) byref(i64) %"67") #1 {
+  %"68" = alloca i64, align 8, addrspace(5)
+  %"69" = alloca i64, align 8, addrspace(5)
+  %"70" = alloca float, align 4, addrspace(5)
+  %"71" = alloca float, align 4, addrspace(5)
+  %"72" = alloca float, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"60"
 
 "60":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"69", align 8
-  store i64 %2, ptr addrspace(5) %"71", align 8
-  %3 = load i64, ptr addrspace(4) %"70", align 8
-  store i64 %3, ptr addrspace(5) %"72", align 8
-  %4 = load i64, ptr addrspace(5) %"71", align 8
-  %"94" = inttoptr i64 %4 to ptr
-  %5 = load float, ptr %"94", align 4
-  store float %5, ptr addrspace(5) %"73", align 4
-  %6 = load i64, ptr addrspace(5) %"71", align 8
-  %"95" = inttoptr i64 %6 to ptr
-  %"38" = getelementptr inbounds i8, ptr %"95", i64 4
+  %2 = load i64, ptr addrspace(4) %"66", align 8
+  store i64 %2, ptr addrspace(5) %"68", align 8
+  %3 = load i64, ptr addrspace(4) %"67", align 8
+  store i64 %3, ptr addrspace(5) %"69", align 8
+  %4 = load i64, ptr addrspace(5) %"68", align 8
+  %"91" = inttoptr i64 %4 to ptr
+  %5 = load float, ptr %"91", align 4
+  store float %5, ptr addrspace(5) %"70", align 4
+  %6 = load i64, ptr addrspace(5) %"68", align 8
+  %"92" = inttoptr i64 %6 to ptr
+  %"38" = getelementptr inbounds i8, ptr %"92", i64 4
   %7 = load float, ptr %"38", align 4
-  store float %7, ptr addrspace(5) %"74", align 4
-  %8 = load float, ptr addrspace(5) %"73", align 4
-  %9 = load float, ptr addrspace(5) %"74", align 4
-  %"82" = fmul float %8, %9
-  store float %"82", ptr addrspace(5) %"75", align 4
-  %10 = load float, ptr addrspace(5) %"73", align 4
-  %11 = load float, ptr addrspace(5) %"74", align 4
+  store float %7, ptr addrspace(5) %"71", align 4
+  %8 = load float, ptr addrspace(5) %"70", align 4
+  %9 = load float, ptr addrspace(5) %"71", align 4
+  %"79" = fmul float %8, %9
+  store float %"79", ptr addrspace(5) %"72", align 4
+  %10 = load float, ptr addrspace(5) %"70", align 4
+  %11 = load float, ptr addrspace(5) %"71", align 4
   %12 = call %struct.f32.f32.f32.i8 @__zluda_ptx_impl_div_f32_part1(float %10, float %11)
   %"43" = extractvalue %struct.f32.f32.f32.i8 %12, 0
   %"44" = extractvalue %struct.f32.f32.f32.i8 %12, 1
   %"45" = extractvalue %struct.f32.f32.f32.i8 %12, 2
   %"46" = extractvalue %struct.f32.f32.f32.i8 %12, 3
-  br label %"63"
-
-"63":                                             ; preds = %"60"
   call void @llvm.amdgcn.s.setreg(i32 6401, i32 0)
-  br label %"61"
-
-"61":                                             ; preds = %"63"
-  %13 = load float, ptr addrspace(5) %"73", align 4
-  %14 = load float, ptr addrspace(5) %"74", align 4
-  %"87" = call float @__zluda_ptx_impl_div_f32_part2(float %13, float %14, float %"43", float %"44", float %"45", i8 %"46")
-  store float %"87", ptr addrspace(5) %"73", align 4
-  br label %"62"
-
-"62":                                             ; preds = %"61"
-  %15 = load i64, ptr addrspace(5) %"72", align 8
-  %16 = load float, ptr addrspace(5) %"73", align 4
-  %"96" = inttoptr i64 %15 to ptr
-  store float %16, ptr %"96", align 4
-  %17 = load i64, ptr addrspace(5) %"72", align 8
-  %"97" = inttoptr i64 %17 to ptr
-  %"40" = getelementptr inbounds i8, ptr %"97", i64 4
-  %18 = load float, ptr addrspace(5) %"75", align 4
+  %13 = load float, ptr addrspace(5) %"70", align 4
+  %14 = load float, ptr addrspace(5) %"71", align 4
+  %"84" = call float @__zluda_ptx_impl_div_f32_part2(float %13, float %14, float %"43", float %"44", float %"45", i8 %"46")
+  store float %"84", ptr addrspace(5) %"70", align 4
+  %15 = load i64, ptr addrspace(5) %"69", align 8
+  %16 = load float, ptr addrspace(5) %"70", align 4
+  %"93" = inttoptr i64 %15 to ptr
+  store float %16, ptr %"93", align 4
+  %17 = load i64, ptr addrspace(5) %"69", align 8
+  %"94" = inttoptr i64 %17 to ptr
+  %"40" = getelementptr inbounds i8, ptr %"94", i64 4
+  %18 = load float, ptr addrspace(5) %"72", align 4
   store float %18, ptr %"40", align 4
   ret void
 }

--- a/ptx/src/test/ll/div_noftz.ll
+++ b/ptx/src/test/ll/div_noftz.ll
@@ -4,61 +4,55 @@ declare hidden %struct.f32.f32.f32.i8 @__zluda_ptx_impl_div_f32_part1(float, flo
 
 declare hidden float @__zluda_ptx_impl_div_f32_part2(float, float, float, float, float, i8) #0
 
-define amdgpu_kernel void @div_noftz(ptr addrspace(4) byref(i64) %"68", ptr addrspace(4) byref(i64) %"69") #1 {
-  %"70" = alloca i64, align 8, addrspace(5)
-  %"71" = alloca i64, align 8, addrspace(5)
+define amdgpu_kernel void @div_noftz(ptr addrspace(4) byref(i64) %"66", ptr addrspace(4) byref(i64) %"67") #1 {
+  %"68" = alloca i64, align 8, addrspace(5)
+  %"69" = alloca i64, align 8, addrspace(5)
+  %"70" = alloca float, align 4, addrspace(5)
+  %"71" = alloca float, align 4, addrspace(5)
   %"72" = alloca float, align 4, addrspace(5)
-  %"73" = alloca float, align 4, addrspace(5)
-  %"74" = alloca float, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"60"
 
 "60":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"68", align 8
-  store i64 %2, ptr addrspace(5) %"70", align 8
-  %3 = load i64, ptr addrspace(4) %"69", align 8
-  store i64 %3, ptr addrspace(5) %"71", align 8
-  %4 = load i64, ptr addrspace(5) %"70", align 8
-  %"93" = inttoptr i64 %4 to ptr
-  %5 = load float, ptr %"93", align 4
-  store float %5, ptr addrspace(5) %"72", align 4
-  %6 = load i64, ptr addrspace(5) %"70", align 8
-  %"94" = inttoptr i64 %6 to ptr
-  %"38" = getelementptr inbounds i8, ptr %"94", i64 4
+  %2 = load i64, ptr addrspace(4) %"66", align 8
+  store i64 %2, ptr addrspace(5) %"68", align 8
+  %3 = load i64, ptr addrspace(4) %"67", align 8
+  store i64 %3, ptr addrspace(5) %"69", align 8
+  %4 = load i64, ptr addrspace(5) %"68", align 8
+  %"91" = inttoptr i64 %4 to ptr
+  %5 = load float, ptr %"91", align 4
+  store float %5, ptr addrspace(5) %"70", align 4
+  %6 = load i64, ptr addrspace(5) %"68", align 8
+  %"92" = inttoptr i64 %6 to ptr
+  %"38" = getelementptr inbounds i8, ptr %"92", i64 4
   %7 = load float, ptr %"38", align 4
-  store float %7, ptr addrspace(5) %"73", align 4
-  %8 = load float, ptr addrspace(5) %"72", align 4
-  %9 = load float, ptr addrspace(5) %"73", align 4
-  %"81" = fmul float %8, %9
-  store float %"81", ptr addrspace(5) %"74", align 4
+  store float %7, ptr addrspace(5) %"71", align 4
+  %8 = load float, ptr addrspace(5) %"70", align 4
+  %9 = load float, ptr addrspace(5) %"71", align 4
+  %"79" = fmul float %8, %9
+  store float %"79", ptr addrspace(5) %"72", align 4
   call void @llvm.amdgcn.s.setreg(i32 6401, i32 3)
-  %10 = load float, ptr addrspace(5) %"72", align 4
-  %11 = load float, ptr addrspace(5) %"73", align 4
+  %10 = load float, ptr addrspace(5) %"70", align 4
+  %11 = load float, ptr addrspace(5) %"71", align 4
   %12 = call %struct.f32.f32.f32.i8 @__zluda_ptx_impl_div_f32_part1(float %10, float %11)
   %"43" = extractvalue %struct.f32.f32.f32.i8 %12, 0
   %"44" = extractvalue %struct.f32.f32.f32.i8 %12, 1
   %"45" = extractvalue %struct.f32.f32.f32.i8 %12, 2
   %"46" = extractvalue %struct.f32.f32.f32.i8 %12, 3
-  br label %"61"
-
-"61":                                             ; preds = %"60"
-  %13 = load float, ptr addrspace(5) %"72", align 4
-  %14 = load float, ptr addrspace(5) %"73", align 4
-  %"86" = call float @__zluda_ptx_impl_div_f32_part2(float %13, float %14, float %"43", float %"44", float %"45", i8 %"46")
-  store float %"86", ptr addrspace(5) %"72", align 4
-  br label %"62"
-
-"62":                                             ; preds = %"61"
-  %15 = load i64, ptr addrspace(5) %"71", align 8
-  %16 = load float, ptr addrspace(5) %"72", align 4
-  %"95" = inttoptr i64 %15 to ptr
-  store float %16, ptr %"95", align 4
-  %17 = load i64, ptr addrspace(5) %"71", align 8
-  %"96" = inttoptr i64 %17 to ptr
-  %"40" = getelementptr inbounds i8, ptr %"96", i64 4
-  %18 = load float, ptr addrspace(5) %"74", align 4
+  %13 = load float, ptr addrspace(5) %"70", align 4
+  %14 = load float, ptr addrspace(5) %"71", align 4
+  %"84" = call float @__zluda_ptx_impl_div_f32_part2(float %13, float %14, float %"43", float %"44", float %"45", i8 %"46")
+  store float %"84", ptr addrspace(5) %"70", align 4
+  %15 = load i64, ptr addrspace(5) %"69", align 8
+  %16 = load float, ptr addrspace(5) %"70", align 4
+  %"93" = inttoptr i64 %15 to ptr
+  store float %16, ptr %"93", align 4
+  %17 = load i64, ptr addrspace(5) %"69", align 8
+  %"94" = inttoptr i64 %17 to ptr
+  %"40" = getelementptr inbounds i8, ptr %"94", i64 4
+  %18 = load float, ptr addrspace(5) %"72", align 4
   store float %18, ptr %"40", align 4
   ret void
 }

--- a/ptx/src/test/ll/lanemask_lt.ll
+++ b/ptx/src/test/ll/lanemask_lt.ll
@@ -1,41 +1,38 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_lanemask_lt() #0
 
-define amdgpu_kernel void @lanemask_lt(ptr addrspace(4) byref(i64) %"42", ptr addrspace(4) byref(i64) %"43") #1 {
+define amdgpu_kernel void @lanemask_lt(ptr addrspace(4) byref(i64) %"41", ptr addrspace(4) byref(i64) %"42") #1 {
+  %"43" = alloca i64, align 8, addrspace(5)
   %"44" = alloca i64, align 8, addrspace(5)
-  %"45" = alloca i64, align 8, addrspace(5)
+  %"45" = alloca i32, align 4, addrspace(5)
   %"46" = alloca i32, align 4, addrspace(5)
   %"47" = alloca i32, align 4, addrspace(5)
-  %"48" = alloca i32, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"39"
 
 "39":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"42", align 8
-  store i64 %2, ptr addrspace(5) %"44", align 8
-  %3 = load i64, ptr addrspace(4) %"43", align 8
-  store i64 %3, ptr addrspace(5) %"45", align 8
-  %4 = load i64, ptr addrspace(5) %"44", align 8
-  %"62" = inttoptr i64 %4 to ptr
-  %5 = load i32, ptr %"62", align 4
-  store i32 %5, ptr addrspace(5) %"46", align 4
-  %6 = load i32, ptr addrspace(5) %"46", align 4
-  %"63" = add i32 %6, 1
-  store i32 %"63", ptr addrspace(5) %"47", align 4
+  %2 = load i64, ptr addrspace(4) %"41", align 8
+  store i64 %2, ptr addrspace(5) %"43", align 8
+  %3 = load i64, ptr addrspace(4) %"42", align 8
+  store i64 %3, ptr addrspace(5) %"44", align 8
+  %4 = load i64, ptr addrspace(5) %"43", align 8
+  %"61" = inttoptr i64 %4 to ptr
+  %5 = load i32, ptr %"61", align 4
+  store i32 %5, ptr addrspace(5) %"45", align 4
+  %6 = load i32, ptr addrspace(5) %"45", align 4
+  %"62" = add i32 %6, 1
+  store i32 %"62", ptr addrspace(5) %"46", align 4
   %"37" = call i32 @__zluda_ptx_impl_sreg_lanemask_lt()
-  br label %"40"
-
-"40":                                             ; preds = %"39"
-  store i32 %"37", ptr addrspace(5) %"48", align 4
-  %7 = load i32, ptr addrspace(5) %"47", align 4
-  %8 = load i32, ptr addrspace(5) %"48", align 4
-  %"66" = add i32 %7, %8
-  store i32 %"66", ptr addrspace(5) %"47", align 4
-  %9 = load i64, ptr addrspace(5) %"45", align 8
-  %10 = load i32, ptr addrspace(5) %"47", align 4
-  %"69" = inttoptr i64 %9 to ptr
-  store i32 %10, ptr %"69", align 4
+  store i32 %"37", ptr addrspace(5) %"47", align 4
+  %7 = load i32, ptr addrspace(5) %"46", align 4
+  %8 = load i32, ptr addrspace(5) %"47", align 4
+  %"65" = add i32 %7, %8
+  store i32 %"65", ptr addrspace(5) %"46", align 4
+  %9 = load i64, ptr addrspace(5) %"44", align 8
+  %10 = load i32, ptr addrspace(5) %"46", align 4
+  %"68" = inttoptr i64 %9 to ptr
+  store i32 %10, ptr %"68", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/ldmatrix.ll
+++ b/ptx/src/test/ll/ldmatrix.ll
@@ -5,93 +5,90 @@ declare hidden <2 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x2_b16(ptr addrspace(3)
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @ldmatrix(ptr addrspace(4) byref(i64) %"58") #1 {
-  %"59" = alloca i64, align 8, addrspace(5)
-  %"60" = alloca i32, align 4, addrspace(5)
+define amdgpu_kernel void @ldmatrix(ptr addrspace(4) byref(i64) %"57") #1 {
+  %"58" = alloca i64, align 8, addrspace(5)
+  %"59" = alloca i32, align 4, addrspace(5)
+  %"60" = alloca i64, align 8, addrspace(5)
   %"61" = alloca i64, align 8, addrspace(5)
-  %"62" = alloca i64, align 8, addrspace(5)
-  %"63" = alloca i32, align 4, addrspace(5)
-  %"64" = alloca i64, align 8, addrspace(5)
+  %"62" = alloca i32, align 4, addrspace(5)
+  %"63" = alloca i64, align 8, addrspace(5)
+  %"64" = alloca i32, align 4, addrspace(5)
   %"65" = alloca i32, align 4, addrspace(5)
   %"66" = alloca i32, align 4, addrspace(5)
-  %"67" = alloca i32, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"55"
 
 "55":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"58", align 8
-  store i64 %2, ptr addrspace(5) %"59", align 8
+  %2 = load i64, ptr addrspace(4) %"57", align 8
+  store i64 %2, ptr addrspace(5) %"58", align 8
   %"43" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"56"
-
-"56":                                             ; preds = %"55"
-  store i32 %"43", ptr addrspace(5) %"60", align 4
-  %3 = load i32, ptr addrspace(5) %"60", align 4
-  %"70" = zext i32 %3 to i64
-  store i64 %"70", ptr addrspace(5) %"61", align 8
-  store i64 ptrtoint (ptr addrspace(1) @values_g to i64), ptr addrspace(5) %"62", align 8
-  %4 = load i64, ptr addrspace(5) %"61", align 8
-  %5 = load i64, ptr addrspace(5) %"62", align 8
-  %6 = mul i64 %4, 4
-  %"73" = add i64 %6, %5
-  store i64 %"73", ptr addrspace(5) %"62", align 8
-  %7 = load i64, ptr addrspace(5) %"62", align 8
-  %"109" = inttoptr i64 %7 to ptr addrspace(1)
-  %8 = load i32, ptr addrspace(1) %"109", align 4
-  store i32 %8, ptr addrspace(5) %"65", align 4
-  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"63", align 4
-  %9 = load i32, ptr addrspace(5) %"60", align 4
-  %10 = load i32, ptr addrspace(5) %"63", align 4
-  %11 = mul i32 %9, 4
-  %"111" = add i32 %11, %10
-  store i32 %"111", ptr addrspace(5) %"63", align 4
-  %12 = load i32, ptr addrspace(5) %"63", align 4
-  %13 = load i32, ptr addrspace(5) %"65", align 4
-  %"113" = inttoptr i32 %12 to ptr addrspace(3)
-  store i32 %13, ptr addrspace(3) %"113", align 4
-  %14 = load i64, ptr addrspace(5) %"62", align 8
-  %"115" = inttoptr i64 %14 to ptr addrspace(1)
-  %"47" = getelementptr inbounds i8, ptr addrspace(1) %"115", i64 128
-  %15 = load i32, ptr addrspace(1) %"47", align 4
-  store i32 %15, ptr addrspace(5) %"65", align 4
-  %16 = load i32, ptr addrspace(5) %"63", align 4
-  %"117" = inttoptr i32 %16 to ptr addrspace(3)
-  %"49" = getelementptr inbounds i8, ptr addrspace(3) %"117", i64 128
-  %17 = load i32, ptr addrspace(5) %"65", align 4
-  store i32 %17, ptr addrspace(3) %"49", align 4
-  store i64 ptrtoint (ptr addrspace(3) @values_s to i64), ptr addrspace(5) %"64", align 8
-  %18 = load i64, ptr addrspace(5) %"64", align 8
-  %19 = inttoptr i64 %18 to ptr addrspace(3)
-  %"89" = addrspacecast ptr addrspace(3) %19 to ptr
-  store ptr %"89", ptr addrspace(5) %"64", align 8
-  %20 = load i64, ptr addrspace(5) %"61", align 8
-  %21 = load i64, ptr addrspace(5) %"64", align 8
-  %22 = mul i64 %20, 16
-  %"120" = add i64 %22, %21
-  store i64 %"120", ptr addrspace(5) %"64", align 8
-  %23 = load i64, ptr addrspace(5) %"64", align 8
-  %"122" = inttoptr i64 %23 to ptr addrspace(3)
-  %"51" = call <2 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x2_b16(ptr addrspace(3) %"122")
-  %"123" = extractelement <2 x i32> %"51", i8 0
-  %"124" = extractelement <2 x i32> %"51", i8 1
+  store i32 %"43", ptr addrspace(5) %"59", align 4
+  %3 = load i32, ptr addrspace(5) %"59", align 4
+  %4 = zext i32 %3 to i64
+  store i64 %4, ptr addrspace(5) %"60", align 8
+  store i64 ptrtoint (ptr addrspace(1) @values_g to i64), ptr addrspace(5) %"61", align 8
+  %5 = load i64, ptr addrspace(5) %"60", align 8
+  %6 = load i64, ptr addrspace(5) %"61", align 8
+  %7 = mul i64 %5, 4
+  %"72" = add i64 %7, %6
+  store i64 %"72", ptr addrspace(5) %"61", align 8
+  %8 = load i64, ptr addrspace(5) %"61", align 8
+  %"108" = inttoptr i64 %8 to ptr addrspace(1)
+  %9 = load i32, ptr addrspace(1) %"108", align 4
+  store i32 %9, ptr addrspace(5) %"64", align 4
+  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"62", align 4
+  %10 = load i32, ptr addrspace(5) %"59", align 4
+  %11 = load i32, ptr addrspace(5) %"62", align 4
+  %12 = mul i32 %10, 4
+  %"110" = add i32 %12, %11
+  store i32 %"110", ptr addrspace(5) %"62", align 4
+  %13 = load i32, ptr addrspace(5) %"62", align 4
+  %14 = load i32, ptr addrspace(5) %"64", align 4
+  %"112" = inttoptr i32 %13 to ptr addrspace(3)
+  store i32 %14, ptr addrspace(3) %"112", align 4
+  %15 = load i64, ptr addrspace(5) %"61", align 8
+  %"114" = inttoptr i64 %15 to ptr addrspace(1)
+  %"47" = getelementptr inbounds i8, ptr addrspace(1) %"114", i64 128
+  %16 = load i32, ptr addrspace(1) %"47", align 4
+  store i32 %16, ptr addrspace(5) %"64", align 4
+  %17 = load i32, ptr addrspace(5) %"62", align 4
+  %"116" = inttoptr i32 %17 to ptr addrspace(3)
+  %"49" = getelementptr inbounds i8, ptr addrspace(3) %"116", i64 128
+  %18 = load i32, ptr addrspace(5) %"64", align 4
+  store i32 %18, ptr addrspace(3) %"49", align 4
+  store i64 ptrtoint (ptr addrspace(3) @values_s to i64), ptr addrspace(5) %"63", align 8
+  %19 = load i64, ptr addrspace(5) %"63", align 8
+  %20 = inttoptr i64 %19 to ptr addrspace(3)
+  %"88" = addrspacecast ptr addrspace(3) %20 to ptr
+  store ptr %"88", ptr addrspace(5) %"63", align 8
+  %21 = load i64, ptr addrspace(5) %"60", align 8
+  %22 = load i64, ptr addrspace(5) %"63", align 8
+  %23 = mul i64 %21, 16
+  %"119" = add i64 %23, %22
+  store i64 %"119", ptr addrspace(5) %"63", align 8
+  %24 = load i64, ptr addrspace(5) %"63", align 8
+  %"121" = inttoptr i64 %24 to ptr addrspace(3)
+  %"51" = call <2 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x2_b16(ptr addrspace(3) %"121")
+  %"122" = extractelement <2 x i32> %"51", i8 0
+  %"123" = extractelement <2 x i32> %"51", i8 1
+  store i32 %"122", ptr addrspace(5) %"65", align 4
   store i32 %"123", ptr addrspace(5) %"66", align 4
-  store i32 %"124", ptr addrspace(5) %"67", align 4
-  %24 = load i64, ptr addrspace(5) %"61", align 8
-  %25 = load i64, ptr addrspace(5) %"59", align 8
-  %26 = mul i64 %24, 8
-  %"97" = add i64 %26, %25
-  store i64 %"97", ptr addrspace(5) %"59", align 8
-  %27 = load i64, ptr addrspace(5) %"59", align 8
-  %28 = load i32, ptr addrspace(5) %"66", align 4
-  %"125" = inttoptr i64 %27 to ptr
-  store i32 %28, ptr %"125", align 4
-  %29 = load i64, ptr addrspace(5) %"59", align 8
-  %"126" = inttoptr i64 %29 to ptr
-  %"54" = getelementptr inbounds i8, ptr %"126", i64 4
-  %30 = load i32, ptr addrspace(5) %"67", align 4
-  store i32 %30, ptr %"54", align 4
+  %25 = load i64, ptr addrspace(5) %"60", align 8
+  %26 = load i64, ptr addrspace(5) %"58", align 8
+  %27 = mul i64 %25, 8
+  %"96" = add i64 %27, %26
+  store i64 %"96", ptr addrspace(5) %"58", align 8
+  %28 = load i64, ptr addrspace(5) %"58", align 8
+  %29 = load i32, ptr addrspace(5) %"65", align 4
+  %"124" = inttoptr i64 %28 to ptr
+  store i32 %29, ptr %"124", align 4
+  %30 = load i64, ptr addrspace(5) %"58", align 8
+  %"125" = inttoptr i64 %30 to ptr
+  %"54" = getelementptr inbounds i8, ptr %"125", i64 4
+  %31 = load i32, ptr addrspace(5) %"66", align 4
+  store i32 %31, ptr %"54", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/ldmatrix_trans.ll
+++ b/ptx/src/test/ll/ldmatrix_trans.ll
@@ -5,158 +5,155 @@ declare hidden <4 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x4_trans_b16(ptr addrsp
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @ldmatrix_trans(ptr addrspace(4) byref(i64) %"89") #1 {
-  %"90" = alloca i64, align 8, addrspace(5)
-  %"91" = alloca i32, align 4, addrspace(5)
+define amdgpu_kernel void @ldmatrix_trans(ptr addrspace(4) byref(i64) %"88") #1 {
+  %"89" = alloca i64, align 8, addrspace(5)
+  %"90" = alloca i32, align 4, addrspace(5)
+  %"91" = alloca i64, align 8, addrspace(5)
   %"92" = alloca i64, align 8, addrspace(5)
-  %"93" = alloca i64, align 8, addrspace(5)
-  %"94" = alloca i32, align 4, addrspace(5)
-  %"95" = alloca i64, align 8, addrspace(5)
-  %"96" = alloca i32, align 4, addrspace(5)
+  %"93" = alloca i32, align 4, addrspace(5)
+  %"94" = alloca i64, align 8, addrspace(5)
+  %"95" = alloca i32, align 4, addrspace(5)
+  %"96" = alloca i64, align 8, addrspace(5)
   %"97" = alloca i64, align 8, addrspace(5)
-  %"98" = alloca i64, align 8, addrspace(5)
+  %"98" = alloca i32, align 4, addrspace(5)
   %"99" = alloca i32, align 4, addrspace(5)
   %"100" = alloca i32, align 4, addrspace(5)
   %"101" = alloca i32, align 4, addrspace(5)
-  %"102" = alloca i32, align 4, addrspace(5)
+  %"102" = alloca <2 x i16>, align 4, addrspace(5)
   %"103" = alloca <2 x i16>, align 4, addrspace(5)
   %"104" = alloca <2 x i16>, align 4, addrspace(5)
   %"105" = alloca <2 x i16>, align 4, addrspace(5)
-  %"106" = alloca <2 x i16>, align 4, addrspace(5)
-  %"111" = alloca i1, align 1, addrspace(5)
+  %"110" = alloca i1, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"86"
 
 "86":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"89", align 8
-  store i64 %2, ptr addrspace(5) %"90", align 8
+  %2 = load i64, ptr addrspace(4) %"88", align 8
+  store i64 %2, ptr addrspace(5) %"89", align 8
   %"55" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"87"
+  store i32 %"55", ptr addrspace(5) %"90", align 4
+  %3 = load i32, ptr addrspace(5) %"90", align 4
+  %4 = zext i32 %3 to i64
+  store i64 %4, ptr addrspace(5) %"91", align 8
+  %5 = load i32, ptr addrspace(5) %"90", align 4
+  %6 = icmp uge i32 %5, 32
+  store i1 %6, ptr addrspace(5) %"110", align 1
+  %7 = load i1, ptr addrspace(5) %"110", align 1
+  br i1 %7, label %"13", label %"33"
 
-"87":                                             ; preds = %"86"
-  store i32 %"55", ptr addrspace(5) %"91", align 4
-  %3 = load i32, ptr addrspace(5) %"91", align 4
-  %"109" = zext i32 %3 to i64
-  store i64 %"109", ptr addrspace(5) %"92", align 8
-  %4 = load i32, ptr addrspace(5) %"91", align 4
-  %5 = icmp uge i32 %4, 32
-  store i1 %5, ptr addrspace(5) %"111", align 1
-  %6 = load i1, ptr addrspace(5) %"111", align 1
-  br i1 %6, label %"13", label %"33"
-
-"33":                                             ; preds = %"87"
-  store i64 ptrtoint (ptr addrspace(1) @values_g to i64), ptr addrspace(5) %"93", align 8
-  %7 = load i64, ptr addrspace(5) %"92", align 8
-  %8 = load i64, ptr addrspace(5) %"93", align 8
-  %9 = mul i64 %7, 16
-  %"116" = add i64 %9, %8
-  store i64 %"116", ptr addrspace(5) %"93", align 8
-  %10 = load i64, ptr addrspace(5) %"93", align 8
-  %"169" = inttoptr i64 %10 to ptr addrspace(1)
-  %11 = load <2 x i64>, ptr addrspace(1) %"169", align 16
-  %"170" = extractelement <2 x i64> %11, i8 0
-  %"171" = extractelement <2 x i64> %11, i8 1
+"33":                                             ; preds = %"86"
+  store i64 ptrtoint (ptr addrspace(1) @values_g to i64), ptr addrspace(5) %"92", align 8
+  %8 = load i64, ptr addrspace(5) %"91", align 8
+  %9 = load i64, ptr addrspace(5) %"92", align 8
+  %10 = mul i64 %8, 16
+  %"115" = add i64 %10, %9
+  store i64 %"115", ptr addrspace(5) %"92", align 8
+  %11 = load i64, ptr addrspace(5) %"92", align 8
+  %"168" = inttoptr i64 %11 to ptr addrspace(1)
+  %12 = load <2 x i64>, ptr addrspace(1) %"168", align 16
+  %"169" = extractelement <2 x i64> %12, i8 0
+  %"170" = extractelement <2 x i64> %12, i8 1
+  store i64 %"169", ptr addrspace(5) %"96", align 8
   store i64 %"170", ptr addrspace(5) %"97", align 8
-  store i64 %"171", ptr addrspace(5) %"98", align 8
-  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"94", align 4
-  %12 = load i32, ptr addrspace(5) %"91", align 4
-  %13 = load i32, ptr addrspace(5) %"94", align 4
-  %14 = mul i32 %12, 16
-  %"173" = add i32 %14, %13
-  store i32 %"173", ptr addrspace(5) %"94", align 4
-  %15 = load i64, ptr addrspace(5) %"97", align 8
-  %16 = load i64, ptr addrspace(5) %"98", align 8
-  %17 = insertelement <2 x i64> undef, i64 %15, i8 0
-  %"60" = insertelement <2 x i64> %17, i64 %16, i8 1
-  %18 = load i32, ptr addrspace(5) %"94", align 4
-  %"177" = inttoptr i32 %18 to ptr addrspace(3)
-  store <2 x i64> %"60", ptr addrspace(3) %"177", align 16
-  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"94", align 4
-  %19 = load i32, ptr addrspace(5) %"91", align 4
-  %20 = load i32, ptr addrspace(5) %"94", align 4
-  %21 = mul i32 %19, 16
-  %"179" = add i32 %21, %20
-  store i32 %"179", ptr addrspace(5) %"94", align 4
-  %22 = load i32, ptr addrspace(5) %"94", align 4
-  %"181" = inttoptr i32 %22 to ptr addrspace(3)
-  %"62" = call <4 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x4_trans_b16(ptr addrspace(3) %"181")
-  %"134" = extractelement <4 x i32> %"62", i8 0
-  %"135" = extractelement <4 x i32> %"62", i8 1
-  %"136" = extractelement <4 x i32> %"62", i8 2
-  %"137" = extractelement <4 x i32> %"62", i8 3
+  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"93", align 4
+  %13 = load i32, ptr addrspace(5) %"90", align 4
+  %14 = load i32, ptr addrspace(5) %"93", align 4
+  %15 = mul i32 %13, 16
+  %"172" = add i32 %15, %14
+  store i32 %"172", ptr addrspace(5) %"93", align 4
+  %16 = load i64, ptr addrspace(5) %"96", align 8
+  %17 = load i64, ptr addrspace(5) %"97", align 8
+  %18 = insertelement <2 x i64> undef, i64 %16, i8 0
+  %"60" = insertelement <2 x i64> %18, i64 %17, i8 1
+  %19 = load i32, ptr addrspace(5) %"93", align 4
+  %"176" = inttoptr i32 %19 to ptr addrspace(3)
+  store <2 x i64> %"60", ptr addrspace(3) %"176", align 16
+  store i32 ptrtoint (ptr addrspace(3) @values_s to i32), ptr addrspace(5) %"93", align 4
+  %20 = load i32, ptr addrspace(5) %"90", align 4
+  %21 = load i32, ptr addrspace(5) %"93", align 4
+  %22 = mul i32 %20, 16
+  %"178" = add i32 %22, %21
+  store i32 %"178", ptr addrspace(5) %"93", align 4
+  %23 = load i32, ptr addrspace(5) %"93", align 4
+  %"180" = inttoptr i32 %23 to ptr addrspace(3)
+  %"62" = call <4 x i32> @__zluda_ptx_impl_ldmatrix_m8n8_x4_trans_b16(ptr addrspace(3) %"180")
+  %"133" = extractelement <4 x i32> %"62", i8 0
+  %"134" = extractelement <4 x i32> %"62", i8 1
+  %"135" = extractelement <4 x i32> %"62", i8 2
+  %"136" = extractelement <4 x i32> %"62", i8 3
+  store i32 %"133", ptr addrspace(5) %"98", align 4
   store i32 %"134", ptr addrspace(5) %"99", align 4
   store i32 %"135", ptr addrspace(5) %"100", align 4
   store i32 %"136", ptr addrspace(5) %"101", align 4
-  store i32 %"137", ptr addrspace(5) %"102", align 4
-  %23 = load i64, ptr addrspace(5) %"92", align 8
-  %24 = load i64, ptr addrspace(5) %"90", align 8
-  %25 = mul i64 %23, 32
-  %"138" = add i64 %25, %24
-  store i64 %"138", ptr addrspace(5) %"90", align 8
-  %26 = load i32, ptr addrspace(5) %"99", align 4
-  %"141" = bitcast i32 %26 to <2 x i16>
-  store <2 x i16> %"141", ptr addrspace(5) %"103", align 4
-  %27 = load <2 x i16>, ptr addrspace(5) %"103", align 4
-  %"64" = extractelement <2 x i16> %27, i8 0
-  %28 = load i64, ptr addrspace(5) %"90", align 8
-  %"183" = inttoptr i64 %28 to ptr
-  store i16 %"64", ptr %"183", align 2
-  %29 = load i64, ptr addrspace(5) %"90", align 8
-  %"184" = inttoptr i64 %29 to ptr
-  %"66" = getelementptr inbounds i8, ptr %"184", i64 4
-  %30 = load <2 x i16>, ptr addrspace(5) %"103", align 4
-  %"67" = extractelement <2 x i16> %30, i8 1
+  %24 = load i64, ptr addrspace(5) %"91", align 8
+  %25 = load i64, ptr addrspace(5) %"89", align 8
+  %26 = mul i64 %24, 32
+  %"137" = add i64 %26, %25
+  store i64 %"137", ptr addrspace(5) %"89", align 8
+  %27 = load i32, ptr addrspace(5) %"98", align 4
+  %"140" = bitcast i32 %27 to <2 x i16>
+  store <2 x i16> %"140", ptr addrspace(5) %"102", align 4
+  %28 = load <2 x i16>, ptr addrspace(5) %"102", align 4
+  %"64" = extractelement <2 x i16> %28, i8 0
+  %29 = load i64, ptr addrspace(5) %"89", align 8
+  %"182" = inttoptr i64 %29 to ptr
+  store i16 %"64", ptr %"182", align 2
+  %30 = load i64, ptr addrspace(5) %"89", align 8
+  %"183" = inttoptr i64 %30 to ptr
+  %"66" = getelementptr inbounds i8, ptr %"183", i64 4
+  %31 = load <2 x i16>, ptr addrspace(5) %"102", align 4
+  %"67" = extractelement <2 x i16> %31, i8 1
   store i16 %"67", ptr %"66", align 2
-  %31 = load i32, ptr addrspace(5) %"100", align 4
-  %"147" = bitcast i32 %31 to <2 x i16>
-  store <2 x i16> %"147", ptr addrspace(5) %"104", align 4
-  %32 = load i64, ptr addrspace(5) %"90", align 8
-  %"186" = inttoptr i64 %32 to ptr
-  %"69" = getelementptr inbounds i8, ptr %"186", i64 8
-  %33 = load <2 x i16>, ptr addrspace(5) %"104", align 4
-  %"70" = extractelement <2 x i16> %33, i8 0
+  %32 = load i32, ptr addrspace(5) %"99", align 4
+  %"146" = bitcast i32 %32 to <2 x i16>
+  store <2 x i16> %"146", ptr addrspace(5) %"103", align 4
+  %33 = load i64, ptr addrspace(5) %"89", align 8
+  %"185" = inttoptr i64 %33 to ptr
+  %"69" = getelementptr inbounds i8, ptr %"185", i64 8
+  %34 = load <2 x i16>, ptr addrspace(5) %"103", align 4
+  %"70" = extractelement <2 x i16> %34, i8 0
   store i16 %"70", ptr %"69", align 2
-  %34 = load i64, ptr addrspace(5) %"90", align 8
-  %"187" = inttoptr i64 %34 to ptr
-  %"72" = getelementptr inbounds i8, ptr %"187", i64 12
-  %35 = load <2 x i16>, ptr addrspace(5) %"104", align 4
-  %"73" = extractelement <2 x i16> %35, i8 1
+  %35 = load i64, ptr addrspace(5) %"89", align 8
+  %"186" = inttoptr i64 %35 to ptr
+  %"72" = getelementptr inbounds i8, ptr %"186", i64 12
+  %36 = load <2 x i16>, ptr addrspace(5) %"103", align 4
+  %"73" = extractelement <2 x i16> %36, i8 1
   store i16 %"73", ptr %"72", align 2
-  %36 = load i32, ptr addrspace(5) %"101", align 4
-  %"153" = bitcast i32 %36 to <2 x i16>
-  store <2 x i16> %"153", ptr addrspace(5) %"105", align 4
-  %37 = load i64, ptr addrspace(5) %"90", align 8
-  %"189" = inttoptr i64 %37 to ptr
-  %"75" = getelementptr inbounds i8, ptr %"189", i64 16
-  %38 = load <2 x i16>, ptr addrspace(5) %"105", align 4
-  %"76" = extractelement <2 x i16> %38, i8 0
+  %37 = load i32, ptr addrspace(5) %"100", align 4
+  %"152" = bitcast i32 %37 to <2 x i16>
+  store <2 x i16> %"152", ptr addrspace(5) %"104", align 4
+  %38 = load i64, ptr addrspace(5) %"89", align 8
+  %"188" = inttoptr i64 %38 to ptr
+  %"75" = getelementptr inbounds i8, ptr %"188", i64 16
+  %39 = load <2 x i16>, ptr addrspace(5) %"104", align 4
+  %"76" = extractelement <2 x i16> %39, i8 0
   store i16 %"76", ptr %"75", align 2
-  %39 = load i64, ptr addrspace(5) %"90", align 8
-  %"190" = inttoptr i64 %39 to ptr
-  %"78" = getelementptr inbounds i8, ptr %"190", i64 20
-  %40 = load <2 x i16>, ptr addrspace(5) %"105", align 4
-  %"79" = extractelement <2 x i16> %40, i8 1
+  %40 = load i64, ptr addrspace(5) %"89", align 8
+  %"189" = inttoptr i64 %40 to ptr
+  %"78" = getelementptr inbounds i8, ptr %"189", i64 20
+  %41 = load <2 x i16>, ptr addrspace(5) %"104", align 4
+  %"79" = extractelement <2 x i16> %41, i8 1
   store i16 %"79", ptr %"78", align 2
-  %41 = load i32, ptr addrspace(5) %"102", align 4
-  %"159" = bitcast i32 %41 to <2 x i16>
-  store <2 x i16> %"159", ptr addrspace(5) %"106", align 4
-  %42 = load i64, ptr addrspace(5) %"90", align 8
-  %"192" = inttoptr i64 %42 to ptr
-  %"81" = getelementptr inbounds i8, ptr %"192", i64 24
-  %43 = load <2 x i16>, ptr addrspace(5) %"106", align 4
-  %"82" = extractelement <2 x i16> %43, i8 0
+  %42 = load i32, ptr addrspace(5) %"101", align 4
+  %"158" = bitcast i32 %42 to <2 x i16>
+  store <2 x i16> %"158", ptr addrspace(5) %"105", align 4
+  %43 = load i64, ptr addrspace(5) %"89", align 8
+  %"191" = inttoptr i64 %43 to ptr
+  %"81" = getelementptr inbounds i8, ptr %"191", i64 24
+  %44 = load <2 x i16>, ptr addrspace(5) %"105", align 4
+  %"82" = extractelement <2 x i16> %44, i8 0
   store i16 %"82", ptr %"81", align 2
-  %44 = load i64, ptr addrspace(5) %"90", align 8
-  %"193" = inttoptr i64 %44 to ptr
-  %"84" = getelementptr inbounds i8, ptr %"193", i64 28
-  %45 = load <2 x i16>, ptr addrspace(5) %"106", align 4
-  %"85" = extractelement <2 x i16> %45, i8 1
+  %45 = load i64, ptr addrspace(5) %"89", align 8
+  %"192" = inttoptr i64 %45 to ptr
+  %"84" = getelementptr inbounds i8, ptr %"192", i64 28
+  %46 = load <2 x i16>, ptr addrspace(5) %"105", align 4
+  %"85" = extractelement <2 x i16> %46, i8 1
   store i16 %"85", ptr %"84", align 2
   br label %"13"
 
-"13":                                             ; preds = %"33", %"87"
+"13":                                             ; preds = %"33", %"86"
   ret void
 }
 

--- a/ptx/src/test/ll/mma_m16n8k16_f32_bf16_bf16_f32.ll
+++ b/ptx/src/test/ll/mma_m16n8k16_f32_bf16_bf16_f32.ll
@@ -1,9 +1,10 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32(ptr addrspace(4) byref(i64) %"76") #1 {
+define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32(ptr addrspace(4) byref(i64) %"75") #1 {
+  %"76" = alloca i64, align 8, addrspace(5)
   %"77" = alloca i64, align 8, addrspace(5)
-  %"78" = alloca i64, align 8, addrspace(5)
-  %"79" = alloca i32, align 4, addrspace(5)
+  %"78" = alloca i32, align 4, addrspace(5)
+  %"79" = alloca float, align 4, addrspace(5)
   %"80" = alloca float, align 4, addrspace(5)
   %"81" = alloca float, align 4, addrspace(5)
   %"82" = alloca float, align 4, addrspace(5)
@@ -11,167 +12,165 @@ define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32(ptr addrspace(4) byref
   %"84" = alloca float, align 4, addrspace(5)
   %"85" = alloca float, align 4, addrspace(5)
   %"86" = alloca float, align 4, addrspace(5)
-  %"87" = alloca float, align 4, addrspace(5)
+  %"87" = alloca i32, align 4, addrspace(5)
   %"88" = alloca i32, align 4, addrspace(5)
   %"89" = alloca i32, align 4, addrspace(5)
   %"90" = alloca i32, align 4, addrspace(5)
   %"91" = alloca i32, align 4, addrspace(5)
   %"92" = alloca i32, align 4, addrspace(5)
-  %"93" = alloca i32, align 4, addrspace(5)
+  %"93" = alloca float, align 4, addrspace(5)
   %"94" = alloca float, align 4, addrspace(5)
   %"95" = alloca float, align 4, addrspace(5)
   %"96" = alloca float, align 4, addrspace(5)
-  %"97" = alloca float, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"73"
 
 "73":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"76", align 8
-  store i64 %2, ptr addrspace(5) %"77", align 8
+  %2 = load i64, ptr addrspace(4) %"75", align 8
+  store i64 %2, ptr addrspace(5) %"76", align 8
   %"53" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"74"
-
-"74":                                             ; preds = %"73"
-  store i32 %"53", ptr addrspace(5) %"79", align 4
-  %3 = load i32, ptr addrspace(5) %"79", align 4
-  %"100" = uitofp i32 %3 to float
-  store float %"100", ptr addrspace(5) %"80", align 4
-  %4 = load float, ptr addrspace(5) %"80", align 4
-  %"102" = fmul float %4, 8.000000e+00
-  store float %"102", ptr addrspace(5) %"80", align 4
-  %5 = load float, ptr addrspace(5) %"80", align 4
-  %"104" = fadd float %5, 1.000000e+00
-  store float %"104", ptr addrspace(5) %"81", align 4
-  %6 = load float, ptr addrspace(5) %"80", align 4
-  %"106" = fadd float %6, 2.000000e+00
-  store float %"106", ptr addrspace(5) %"82", align 4
-  %7 = load float, ptr addrspace(5) %"80", align 4
-  %"108" = fadd float %7, 3.000000e+00
-  store float %"108", ptr addrspace(5) %"83", align 4
-  %8 = load float, ptr addrspace(5) %"80", align 4
-  %"110" = fadd float %8, 4.000000e+00
-  store float %"110", ptr addrspace(5) %"84", align 4
-  %9 = load float, ptr addrspace(5) %"80", align 4
-  %"112" = fadd float %9, 5.000000e+00
-  store float %"112", ptr addrspace(5) %"85", align 4
-  %10 = load float, ptr addrspace(5) %"80", align 4
-  %"114" = fadd float %10, 6.000000e+00
-  store float %"114", ptr addrspace(5) %"86", align 4
-  %11 = load float, ptr addrspace(5) %"80", align 4
-  %"116" = fadd float %11, 7.000000e+00
-  store float %"116", ptr addrspace(5) %"87", align 4
-  %12 = load float, ptr addrspace(5) %"80", align 4
-  %13 = load float, ptr addrspace(5) %"81", align 4
+  store i32 %"53", ptr addrspace(5) %"78", align 4
+  %3 = load i32, ptr addrspace(5) %"78", align 4
+  %"99" = uitofp i32 %3 to float
+  store float %"99", ptr addrspace(5) %"79", align 4
+  %4 = load float, ptr addrspace(5) %"79", align 4
+  %"101" = fmul float %4, 8.000000e+00
+  store float %"101", ptr addrspace(5) %"79", align 4
+  %5 = load float, ptr addrspace(5) %"79", align 4
+  %"103" = fadd float %5, 1.000000e+00
+  store float %"103", ptr addrspace(5) %"80", align 4
+  %6 = load float, ptr addrspace(5) %"79", align 4
+  %"105" = fadd float %6, 2.000000e+00
+  store float %"105", ptr addrspace(5) %"81", align 4
+  %7 = load float, ptr addrspace(5) %"79", align 4
+  %"107" = fadd float %7, 3.000000e+00
+  store float %"107", ptr addrspace(5) %"82", align 4
+  %8 = load float, ptr addrspace(5) %"79", align 4
+  %"109" = fadd float %8, 4.000000e+00
+  store float %"109", ptr addrspace(5) %"83", align 4
+  %9 = load float, ptr addrspace(5) %"79", align 4
+  %"111" = fadd float %9, 5.000000e+00
+  store float %"111", ptr addrspace(5) %"84", align 4
+  %10 = load float, ptr addrspace(5) %"79", align 4
+  %"113" = fadd float %10, 6.000000e+00
+  store float %"113", ptr addrspace(5) %"85", align 4
+  %11 = load float, ptr addrspace(5) %"79", align 4
+  %"115" = fadd float %11, 7.000000e+00
+  store float %"115", ptr addrspace(5) %"86", align 4
+  %12 = load float, ptr addrspace(5) %"79", align 4
+  %13 = load float, ptr addrspace(5) %"80", align 4
   %14 = fptrunc float %12 to bfloat
-  %15 = insertelement <2 x bfloat> poison, bfloat %14, i32 1
-  %16 = fptrunc float %13 to bfloat
-  %"165" = insertelement <2 x bfloat> %15, bfloat %16, i32 0
-  %"118" = bitcast <2 x bfloat> %"165" to i32
-  store i32 %"118", ptr addrspace(5) %"88", align 4
-  %17 = load float, ptr addrspace(5) %"82", align 4
-  %18 = load float, ptr addrspace(5) %"83", align 4
+  %15 = fptrunc float %13 to bfloat
+  %16 = insertelement <2 x bfloat> poison, bfloat %14, i32 1
+  %"164" = insertelement <2 x bfloat> %16, bfloat %15, i32 0
+  %"117" = bitcast <2 x bfloat> %"164" to i32
+  store i32 %"117", ptr addrspace(5) %"87", align 4
+  %17 = load float, ptr addrspace(5) %"81", align 4
+  %18 = load float, ptr addrspace(5) %"82", align 4
   %19 = fptrunc float %17 to bfloat
-  %20 = insertelement <2 x bfloat> poison, bfloat %19, i32 1
-  %21 = fptrunc float %18 to bfloat
-  %"166" = insertelement <2 x bfloat> %20, bfloat %21, i32 0
-  %"121" = bitcast <2 x bfloat> %"166" to i32
-  store i32 %"121", ptr addrspace(5) %"89", align 4
-  %22 = load float, ptr addrspace(5) %"84", align 4
-  %23 = load float, ptr addrspace(5) %"85", align 4
+  %20 = fptrunc float %18 to bfloat
+  %21 = insertelement <2 x bfloat> poison, bfloat %19, i32 1
+  %"165" = insertelement <2 x bfloat> %21, bfloat %20, i32 0
+  %"120" = bitcast <2 x bfloat> %"165" to i32
+  store i32 %"120", ptr addrspace(5) %"88", align 4
+  %22 = load float, ptr addrspace(5) %"83", align 4
+  %23 = load float, ptr addrspace(5) %"84", align 4
   %24 = fptrunc float %22 to bfloat
-  %25 = insertelement <2 x bfloat> poison, bfloat %24, i32 1
-  %26 = fptrunc float %23 to bfloat
-  %"167" = insertelement <2 x bfloat> %25, bfloat %26, i32 0
-  %"124" = bitcast <2 x bfloat> %"167" to i32
-  store i32 %"124", ptr addrspace(5) %"90", align 4
-  %27 = load float, ptr addrspace(5) %"86", align 4
-  %28 = load float, ptr addrspace(5) %"87", align 4
+  %25 = fptrunc float %23 to bfloat
+  %26 = insertelement <2 x bfloat> poison, bfloat %24, i32 1
+  %"166" = insertelement <2 x bfloat> %26, bfloat %25, i32 0
+  %"123" = bitcast <2 x bfloat> %"166" to i32
+  store i32 %"123", ptr addrspace(5) %"89", align 4
+  %27 = load float, ptr addrspace(5) %"85", align 4
+  %28 = load float, ptr addrspace(5) %"86", align 4
   %29 = fptrunc float %27 to bfloat
-  %30 = insertelement <2 x bfloat> poison, bfloat %29, i32 1
-  %31 = fptrunc float %28 to bfloat
-  %"168" = insertelement <2 x bfloat> %30, bfloat %31, i32 0
-  %"127" = bitcast <2 x bfloat> %"168" to i32
-  store i32 %"127", ptr addrspace(5) %"91", align 4
-  %32 = load float, ptr addrspace(5) %"80", align 4
-  %33 = load float, ptr addrspace(5) %"81", align 4
+  %30 = fptrunc float %28 to bfloat
+  %31 = insertelement <2 x bfloat> poison, bfloat %29, i32 1
+  %"167" = insertelement <2 x bfloat> %31, bfloat %30, i32 0
+  %"126" = bitcast <2 x bfloat> %"167" to i32
+  store i32 %"126", ptr addrspace(5) %"90", align 4
+  %32 = load float, ptr addrspace(5) %"79", align 4
+  %33 = load float, ptr addrspace(5) %"80", align 4
   %34 = fptrunc float %32 to bfloat
-  %35 = insertelement <2 x bfloat> poison, bfloat %34, i32 1
-  %36 = fptrunc float %33 to bfloat
-  %"169" = insertelement <2 x bfloat> %35, bfloat %36, i32 0
-  %"130" = bitcast <2 x bfloat> %"169" to i32
-  store i32 %"130", ptr addrspace(5) %"92", align 4
-  %37 = load float, ptr addrspace(5) %"82", align 4
-  %38 = load float, ptr addrspace(5) %"83", align 4
+  %35 = fptrunc float %33 to bfloat
+  %36 = insertelement <2 x bfloat> poison, bfloat %34, i32 1
+  %"168" = insertelement <2 x bfloat> %36, bfloat %35, i32 0
+  %"129" = bitcast <2 x bfloat> %"168" to i32
+  store i32 %"129", ptr addrspace(5) %"91", align 4
+  %37 = load float, ptr addrspace(5) %"81", align 4
+  %38 = load float, ptr addrspace(5) %"82", align 4
   %39 = fptrunc float %37 to bfloat
-  %40 = insertelement <2 x bfloat> poison, bfloat %39, i32 1
-  %41 = fptrunc float %38 to bfloat
-  %"170" = insertelement <2 x bfloat> %40, bfloat %41, i32 0
-  %"133" = bitcast <2 x bfloat> %"170" to i32
-  store i32 %"133", ptr addrspace(5) %"93", align 4
-  %42 = load i32, ptr addrspace(5) %"88", align 4
-  %43 = load i32, ptr addrspace(5) %"89", align 4
-  %44 = load i32, ptr addrspace(5) %"90", align 4
-  %45 = load i32, ptr addrspace(5) %"91", align 4
+  %40 = fptrunc float %38 to bfloat
+  %41 = insertelement <2 x bfloat> poison, bfloat %39, i32 1
+  %"169" = insertelement <2 x bfloat> %41, bfloat %40, i32 0
+  %"132" = bitcast <2 x bfloat> %"169" to i32
+  store i32 %"132", ptr addrspace(5) %"92", align 4
+  %42 = load i32, ptr addrspace(5) %"87", align 4
+  %43 = load i32, ptr addrspace(5) %"88", align 4
+  %44 = load i32, ptr addrspace(5) %"89", align 4
+  %45 = load i32, ptr addrspace(5) %"90", align 4
   %46 = insertelement <4 x i32> undef, i32 %42, i8 0
   %47 = insertelement <4 x i32> %46, i32 %43, i8 1
   %48 = insertelement <4 x i32> %47, i32 %44, i8 2
   %"63" = insertelement <4 x i32> %48, i32 %45, i8 3
-  %49 = load i32, ptr addrspace(5) %"92", align 4
-  %50 = load i32, ptr addrspace(5) %"93", align 4
+  %49 = load i32, ptr addrspace(5) %"91", align 4
+  %50 = load i32, ptr addrspace(5) %"92", align 4
   %51 = insertelement <2 x i32> undef, i32 %49, i8 0
   %"64" = insertelement <2 x i32> %51, i32 %50, i8 1
-  %52 = load float, ptr addrspace(5) %"80", align 4
-  %53 = load float, ptr addrspace(5) %"81", align 4
-  %54 = load float, ptr addrspace(5) %"82", align 4
-  %55 = load float, ptr addrspace(5) %"83", align 4
+  %52 = load float, ptr addrspace(5) %"79", align 4
+  %53 = load float, ptr addrspace(5) %"80", align 4
+  %54 = load float, ptr addrspace(5) %"81", align 4
+  %55 = load float, ptr addrspace(5) %"82", align 4
   %56 = insertelement <4 x float> undef, float %52, i8 0
   %57 = insertelement <4 x float> %56, float %53, i8 1
   %58 = insertelement <4 x float> %57, float %54, i8 2
   %"65" = insertelement <4 x float> %58, float %55, i8 3
   %"62" = call <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32> %"63", <2 x i32> %"64", <4 x float> %"65")
-  %"146" = extractelement <4 x float> %"62", i8 0
-  %"147" = extractelement <4 x float> %"62", i8 1
-  %"148" = extractelement <4 x float> %"62", i8 2
-  %"149" = extractelement <4 x float> %"62", i8 3
+  %"145" = extractelement <4 x float> %"62", i8 0
+  %"146" = extractelement <4 x float> %"62", i8 1
+  %"147" = extractelement <4 x float> %"62", i8 2
+  %"148" = extractelement <4 x float> %"62", i8 3
+  store float %"145", ptr addrspace(5) %"93", align 4
   store float %"146", ptr addrspace(5) %"94", align 4
   store float %"147", ptr addrspace(5) %"95", align 4
   store float %"148", ptr addrspace(5) %"96", align 4
-  store float %"149", ptr addrspace(5) %"97", align 4
-  %59 = load i32, ptr addrspace(5) %"79", align 4
-  %"150" = zext i32 %59 to i64
-  store i64 %"150", ptr addrspace(5) %"78", align 8
-  %60 = load i64, ptr addrspace(5) %"78", align 8
-  %"152" = mul i64 %60, 16
-  store i64 %"152", ptr addrspace(5) %"78", align 8
+  %59 = load i32, ptr addrspace(5) %"78", align 4
+  %60 = zext i32 %59 to i64
+  store i64 %60, ptr addrspace(5) %"77", align 8
   %61 = load i64, ptr addrspace(5) %"77", align 8
-  %62 = load i64, ptr addrspace(5) %"78", align 8
-  %"154" = add i64 %61, %62
-  store i64 %"154", ptr addrspace(5) %"77", align 8
+  %"151" = mul i64 %61, 16
+  store i64 %"151", ptr addrspace(5) %"77", align 8
+  %62 = load i64, ptr addrspace(5) %"76", align 8
   %63 = load i64, ptr addrspace(5) %"77", align 8
-  %64 = load float, ptr addrspace(5) %"94", align 4
-  %"177" = inttoptr i64 %63 to ptr
-  store float %64, ptr %"177", align 4
-  %65 = load i64, ptr addrspace(5) %"77", align 8
-  %"178" = inttoptr i64 %65 to ptr
-  %"68" = getelementptr inbounds i8, ptr %"178", i64 4
-  %66 = load float, ptr addrspace(5) %"95", align 4
-  store float %66, ptr %"68", align 4
-  %67 = load i64, ptr addrspace(5) %"77", align 8
-  %"179" = inttoptr i64 %67 to ptr
-  %"70" = getelementptr inbounds i8, ptr %"179", i64 8
-  %68 = load float, ptr addrspace(5) %"96", align 4
-  store float %68, ptr %"70", align 4
-  %69 = load i64, ptr addrspace(5) %"77", align 8
-  %"180" = inttoptr i64 %69 to ptr
-  %"72" = getelementptr inbounds i8, ptr %"180", i64 12
-  %70 = load float, ptr addrspace(5) %"97", align 4
-  store float %70, ptr %"72", align 4
+  %"153" = add i64 %62, %63
+  store i64 %"153", ptr addrspace(5) %"76", align 8
+  %64 = load i64, ptr addrspace(5) %"76", align 8
+  %65 = load float, ptr addrspace(5) %"93", align 4
+  %"176" = inttoptr i64 %64 to ptr
+  store float %65, ptr %"176", align 4
+  %66 = load i64, ptr addrspace(5) %"76", align 8
+  %"177" = inttoptr i64 %66 to ptr
+  %"68" = getelementptr inbounds i8, ptr %"177", i64 4
+  %67 = load float, ptr addrspace(5) %"94", align 4
+  store float %67, ptr %"68", align 4
+  %68 = load i64, ptr addrspace(5) %"76", align 8
+  %"178" = inttoptr i64 %68 to ptr
+  %"70" = getelementptr inbounds i8, ptr %"178", i64 8
+  %69 = load float, ptr addrspace(5) %"95", align 4
+  store float %69, ptr %"70", align 4
+  %70 = load i64, ptr addrspace(5) %"76", align 8
+  %"179" = inttoptr i64 %70 to ptr
+  %"72" = getelementptr inbounds i8, ptr %"179", i64 12
+  %71 = load float, ptr addrspace(5) %"96", align 4
+  store float %71, ptr %"72", align 4
   ret void
 }
 
-declare <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32>, <2 x i32>, <4 x float>)
+; Function Attrs: convergent nocallback nofree nosync nounwind willreturn memory(none)
+declare <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32>, <2 x i32>, <4 x float>) #2
 
 attributes #0 = { "amdgpu-ieee"="false" "amdgpu-unsafe-fp-atomics"="true" "denormal-fp-math"="dynamic" "denormal-fp-math-f32"="dynamic" "no-trapping-math"="true" "uniform-work-group-size"="true" }
 attributes #1 = { "amdgpu-ieee"="false" "amdgpu-unsafe-fp-atomics"="true" "denormal-fp-math"="ieee" "denormal-fp-math-f32"="ieee" "no-trapping-math"="true" "uniform-work-group-size"="true" }
+attributes #2 = { convergent nocallback nofree nosync nounwind willreturn memory(none) }

--- a/ptx/src/test/ll/mma_m16n8k16_f32_bf16_bf16_f32_2x.ll
+++ b/ptx/src/test/ll/mma_m16n8k16_f32_bf16_bf16_f32_2x.ll
@@ -1,9 +1,10 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32_2x(ptr addrspace(4) byref(i64) %"94") #1 {
+define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32_2x(ptr addrspace(4) byref(i64) %"93") #1 {
+  %"94" = alloca i64, align 8, addrspace(5)
   %"95" = alloca i64, align 8, addrspace(5)
-  %"96" = alloca i64, align 8, addrspace(5)
-  %"97" = alloca i32, align 4, addrspace(5)
+  %"96" = alloca i32, align 4, addrspace(5)
+  %"97" = alloca float, align 4, addrspace(5)
   %"98" = alloca float, align 4, addrspace(5)
   %"99" = alloca float, align 4, addrspace(5)
   %"100" = alloca float, align 4, addrspace(5)
@@ -11,7 +12,7 @@ define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32_2x(ptr addrspace(4) by
   %"102" = alloca float, align 4, addrspace(5)
   %"103" = alloca float, align 4, addrspace(5)
   %"104" = alloca float, align 4, addrspace(5)
-  %"105" = alloca float, align 4, addrspace(5)
+  %"105" = alloca i32, align 4, addrspace(5)
   %"106" = alloca i32, align 4, addrspace(5)
   %"107" = alloca i32, align 4, addrspace(5)
   %"108" = alloca i32, align 4, addrspace(5)
@@ -19,7 +20,7 @@ define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32_2x(ptr addrspace(4) by
   %"110" = alloca i32, align 4, addrspace(5)
   %"111" = alloca i32, align 4, addrspace(5)
   %"112" = alloca i32, align 4, addrspace(5)
-  %"113" = alloca i32, align 4, addrspace(5)
+  %"113" = alloca float, align 4, addrspace(5)
   %"114" = alloca float, align 4, addrspace(5)
   %"115" = alloca float, align 4, addrspace(5)
   %"116" = alloca float, align 4, addrspace(5)
@@ -27,222 +28,220 @@ define amdgpu_kernel void @mma_m16n8k16_f32_bf16_bf16_f32_2x(ptr addrspace(4) by
   %"118" = alloca float, align 4, addrspace(5)
   %"119" = alloca float, align 4, addrspace(5)
   %"120" = alloca float, align 4, addrspace(5)
-  %"121" = alloca float, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"91"
 
 "91":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"94", align 8
-  store i64 %2, ptr addrspace(5) %"95", align 8
+  %2 = load i64, ptr addrspace(4) %"93", align 8
+  store i64 %2, ptr addrspace(5) %"94", align 8
   %"59" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"92"
-
-"92":                                             ; preds = %"91"
-  store i32 %"59", ptr addrspace(5) %"97", align 4
-  %3 = load i32, ptr addrspace(5) %"97", align 4
-  %"124" = uitofp i32 %3 to float
-  store float %"124", ptr addrspace(5) %"98", align 4
-  %4 = load float, ptr addrspace(5) %"98", align 4
-  %"126" = fmul float %4, 8.000000e+00
-  store float %"126", ptr addrspace(5) %"98", align 4
-  %5 = load float, ptr addrspace(5) %"98", align 4
-  %"128" = fadd float %5, 1.000000e+00
-  store float %"128", ptr addrspace(5) %"99", align 4
-  %6 = load float, ptr addrspace(5) %"98", align 4
-  %"130" = fadd float %6, 2.000000e+00
-  store float %"130", ptr addrspace(5) %"100", align 4
-  %7 = load float, ptr addrspace(5) %"98", align 4
-  %"132" = fadd float %7, 3.000000e+00
-  store float %"132", ptr addrspace(5) %"101", align 4
-  %8 = load float, ptr addrspace(5) %"98", align 4
-  %"134" = fadd float %8, 4.000000e+00
-  store float %"134", ptr addrspace(5) %"102", align 4
-  %9 = load float, ptr addrspace(5) %"98", align 4
-  %"136" = fadd float %9, 5.000000e+00
-  store float %"136", ptr addrspace(5) %"103", align 4
-  %10 = load float, ptr addrspace(5) %"98", align 4
-  %"138" = fadd float %10, 6.000000e+00
-  store float %"138", ptr addrspace(5) %"104", align 4
-  %11 = load float, ptr addrspace(5) %"98", align 4
-  %"140" = fadd float %11, 7.000000e+00
-  store float %"140", ptr addrspace(5) %"105", align 4
-  %12 = load float, ptr addrspace(5) %"98", align 4
-  %13 = load float, ptr addrspace(5) %"99", align 4
+  store i32 %"59", ptr addrspace(5) %"96", align 4
+  %3 = load i32, ptr addrspace(5) %"96", align 4
+  %"123" = uitofp i32 %3 to float
+  store float %"123", ptr addrspace(5) %"97", align 4
+  %4 = load float, ptr addrspace(5) %"97", align 4
+  %"125" = fmul float %4, 8.000000e+00
+  store float %"125", ptr addrspace(5) %"97", align 4
+  %5 = load float, ptr addrspace(5) %"97", align 4
+  %"127" = fadd float %5, 1.000000e+00
+  store float %"127", ptr addrspace(5) %"98", align 4
+  %6 = load float, ptr addrspace(5) %"97", align 4
+  %"129" = fadd float %6, 2.000000e+00
+  store float %"129", ptr addrspace(5) %"99", align 4
+  %7 = load float, ptr addrspace(5) %"97", align 4
+  %"131" = fadd float %7, 3.000000e+00
+  store float %"131", ptr addrspace(5) %"100", align 4
+  %8 = load float, ptr addrspace(5) %"97", align 4
+  %"133" = fadd float %8, 4.000000e+00
+  store float %"133", ptr addrspace(5) %"101", align 4
+  %9 = load float, ptr addrspace(5) %"97", align 4
+  %"135" = fadd float %9, 5.000000e+00
+  store float %"135", ptr addrspace(5) %"102", align 4
+  %10 = load float, ptr addrspace(5) %"97", align 4
+  %"137" = fadd float %10, 6.000000e+00
+  store float %"137", ptr addrspace(5) %"103", align 4
+  %11 = load float, ptr addrspace(5) %"97", align 4
+  %"139" = fadd float %11, 7.000000e+00
+  store float %"139", ptr addrspace(5) %"104", align 4
+  %12 = load float, ptr addrspace(5) %"97", align 4
+  %13 = load float, ptr addrspace(5) %"98", align 4
   %14 = fptrunc float %12 to bfloat
-  %15 = insertelement <2 x bfloat> poison, bfloat %14, i32 1
-  %16 = fptrunc float %13 to bfloat
-  %"217" = insertelement <2 x bfloat> %15, bfloat %16, i32 0
-  %"142" = bitcast <2 x bfloat> %"217" to i32
-  store i32 %"142", ptr addrspace(5) %"106", align 4
-  %17 = load float, ptr addrspace(5) %"100", align 4
-  %18 = load float, ptr addrspace(5) %"101", align 4
+  %15 = fptrunc float %13 to bfloat
+  %16 = insertelement <2 x bfloat> poison, bfloat %14, i32 1
+  %"216" = insertelement <2 x bfloat> %16, bfloat %15, i32 0
+  %"141" = bitcast <2 x bfloat> %"216" to i32
+  store i32 %"141", ptr addrspace(5) %"105", align 4
+  %17 = load float, ptr addrspace(5) %"99", align 4
+  %18 = load float, ptr addrspace(5) %"100", align 4
   %19 = fptrunc float %17 to bfloat
-  %20 = insertelement <2 x bfloat> poison, bfloat %19, i32 1
-  %21 = fptrunc float %18 to bfloat
-  %"218" = insertelement <2 x bfloat> %20, bfloat %21, i32 0
-  %"145" = bitcast <2 x bfloat> %"218" to i32
-  store i32 %"145", ptr addrspace(5) %"107", align 4
-  %22 = load float, ptr addrspace(5) %"102", align 4
-  %23 = load float, ptr addrspace(5) %"103", align 4
+  %20 = fptrunc float %18 to bfloat
+  %21 = insertelement <2 x bfloat> poison, bfloat %19, i32 1
+  %"217" = insertelement <2 x bfloat> %21, bfloat %20, i32 0
+  %"144" = bitcast <2 x bfloat> %"217" to i32
+  store i32 %"144", ptr addrspace(5) %"106", align 4
+  %22 = load float, ptr addrspace(5) %"101", align 4
+  %23 = load float, ptr addrspace(5) %"102", align 4
   %24 = fptrunc float %22 to bfloat
-  %25 = insertelement <2 x bfloat> poison, bfloat %24, i32 1
-  %26 = fptrunc float %23 to bfloat
-  %"219" = insertelement <2 x bfloat> %25, bfloat %26, i32 0
-  %"148" = bitcast <2 x bfloat> %"219" to i32
-  store i32 %"148", ptr addrspace(5) %"108", align 4
-  %27 = load float, ptr addrspace(5) %"104", align 4
-  %28 = load float, ptr addrspace(5) %"105", align 4
+  %25 = fptrunc float %23 to bfloat
+  %26 = insertelement <2 x bfloat> poison, bfloat %24, i32 1
+  %"218" = insertelement <2 x bfloat> %26, bfloat %25, i32 0
+  %"147" = bitcast <2 x bfloat> %"218" to i32
+  store i32 %"147", ptr addrspace(5) %"107", align 4
+  %27 = load float, ptr addrspace(5) %"103", align 4
+  %28 = load float, ptr addrspace(5) %"104", align 4
   %29 = fptrunc float %27 to bfloat
-  %30 = insertelement <2 x bfloat> poison, bfloat %29, i32 1
-  %31 = fptrunc float %28 to bfloat
-  %"220" = insertelement <2 x bfloat> %30, bfloat %31, i32 0
-  %"151" = bitcast <2 x bfloat> %"220" to i32
-  store i32 %"151", ptr addrspace(5) %"109", align 4
-  %32 = load float, ptr addrspace(5) %"98", align 4
-  %33 = load float, ptr addrspace(5) %"99", align 4
+  %30 = fptrunc float %28 to bfloat
+  %31 = insertelement <2 x bfloat> poison, bfloat %29, i32 1
+  %"219" = insertelement <2 x bfloat> %31, bfloat %30, i32 0
+  %"150" = bitcast <2 x bfloat> %"219" to i32
+  store i32 %"150", ptr addrspace(5) %"108", align 4
+  %32 = load float, ptr addrspace(5) %"97", align 4
+  %33 = load float, ptr addrspace(5) %"98", align 4
   %34 = fptrunc float %32 to bfloat
-  %35 = insertelement <2 x bfloat> poison, bfloat %34, i32 1
-  %36 = fptrunc float %33 to bfloat
-  %"221" = insertelement <2 x bfloat> %35, bfloat %36, i32 0
-  %"154" = bitcast <2 x bfloat> %"221" to i32
-  store i32 %"154", ptr addrspace(5) %"110", align 4
-  %37 = load float, ptr addrspace(5) %"100", align 4
-  %38 = load float, ptr addrspace(5) %"101", align 4
+  %35 = fptrunc float %33 to bfloat
+  %36 = insertelement <2 x bfloat> poison, bfloat %34, i32 1
+  %"220" = insertelement <2 x bfloat> %36, bfloat %35, i32 0
+  %"153" = bitcast <2 x bfloat> %"220" to i32
+  store i32 %"153", ptr addrspace(5) %"109", align 4
+  %37 = load float, ptr addrspace(5) %"99", align 4
+  %38 = load float, ptr addrspace(5) %"100", align 4
   %39 = fptrunc float %37 to bfloat
-  %40 = insertelement <2 x bfloat> poison, bfloat %39, i32 1
-  %41 = fptrunc float %38 to bfloat
-  %"222" = insertelement <2 x bfloat> %40, bfloat %41, i32 0
-  %"157" = bitcast <2 x bfloat> %"222" to i32
-  store i32 %"157", ptr addrspace(5) %"111", align 4
-  %42 = load float, ptr addrspace(5) %"102", align 4
-  %43 = load float, ptr addrspace(5) %"103", align 4
+  %40 = fptrunc float %38 to bfloat
+  %41 = insertelement <2 x bfloat> poison, bfloat %39, i32 1
+  %"221" = insertelement <2 x bfloat> %41, bfloat %40, i32 0
+  %"156" = bitcast <2 x bfloat> %"221" to i32
+  store i32 %"156", ptr addrspace(5) %"110", align 4
+  %42 = load float, ptr addrspace(5) %"101", align 4
+  %43 = load float, ptr addrspace(5) %"102", align 4
   %44 = fptrunc float %42 to bfloat
-  %45 = insertelement <2 x bfloat> poison, bfloat %44, i32 1
-  %46 = fptrunc float %43 to bfloat
-  %"223" = insertelement <2 x bfloat> %45, bfloat %46, i32 0
-  %"160" = bitcast <2 x bfloat> %"223" to i32
-  store i32 %"160", ptr addrspace(5) %"112", align 4
-  %47 = load float, ptr addrspace(5) %"104", align 4
-  %48 = load float, ptr addrspace(5) %"105", align 4
+  %45 = fptrunc float %43 to bfloat
+  %46 = insertelement <2 x bfloat> poison, bfloat %44, i32 1
+  %"222" = insertelement <2 x bfloat> %46, bfloat %45, i32 0
+  %"159" = bitcast <2 x bfloat> %"222" to i32
+  store i32 %"159", ptr addrspace(5) %"111", align 4
+  %47 = load float, ptr addrspace(5) %"103", align 4
+  %48 = load float, ptr addrspace(5) %"104", align 4
   %49 = fptrunc float %47 to bfloat
-  %50 = insertelement <2 x bfloat> poison, bfloat %49, i32 1
-  %51 = fptrunc float %48 to bfloat
-  %"224" = insertelement <2 x bfloat> %50, bfloat %51, i32 0
-  %"163" = bitcast <2 x bfloat> %"224" to i32
-  store i32 %"163", ptr addrspace(5) %"113", align 4
-  %52 = load i32, ptr addrspace(5) %"106", align 4
-  %53 = load i32, ptr addrspace(5) %"107", align 4
-  %54 = load i32, ptr addrspace(5) %"108", align 4
-  %55 = load i32, ptr addrspace(5) %"109", align 4
+  %50 = fptrunc float %48 to bfloat
+  %51 = insertelement <2 x bfloat> poison, bfloat %49, i32 1
+  %"223" = insertelement <2 x bfloat> %51, bfloat %50, i32 0
+  %"162" = bitcast <2 x bfloat> %"223" to i32
+  store i32 %"162", ptr addrspace(5) %"112", align 4
+  %52 = load i32, ptr addrspace(5) %"105", align 4
+  %53 = load i32, ptr addrspace(5) %"106", align 4
+  %54 = load i32, ptr addrspace(5) %"107", align 4
+  %55 = load i32, ptr addrspace(5) %"108", align 4
   %56 = insertelement <4 x i32> undef, i32 %52, i8 0
   %57 = insertelement <4 x i32> %56, i32 %53, i8 1
   %58 = insertelement <4 x i32> %57, i32 %54, i8 2
   %"69" = insertelement <4 x i32> %58, i32 %55, i8 3
-  %59 = load i32, ptr addrspace(5) %"110", align 4
-  %60 = load i32, ptr addrspace(5) %"111", align 4
+  %59 = load i32, ptr addrspace(5) %"109", align 4
+  %60 = load i32, ptr addrspace(5) %"110", align 4
   %61 = insertelement <2 x i32> undef, i32 %59, i8 0
   %"70" = insertelement <2 x i32> %61, i32 %60, i8 1
-  %62 = load float, ptr addrspace(5) %"98", align 4
-  %63 = load float, ptr addrspace(5) %"99", align 4
-  %64 = load float, ptr addrspace(5) %"100", align 4
-  %65 = load float, ptr addrspace(5) %"101", align 4
+  %62 = load float, ptr addrspace(5) %"97", align 4
+  %63 = load float, ptr addrspace(5) %"98", align 4
+  %64 = load float, ptr addrspace(5) %"99", align 4
+  %65 = load float, ptr addrspace(5) %"100", align 4
   %66 = insertelement <4 x float> undef, float %62, i8 0
   %67 = insertelement <4 x float> %66, float %63, i8 1
   %68 = insertelement <4 x float> %67, float %64, i8 2
   %"71" = insertelement <4 x float> %68, float %65, i8 3
   %"68" = call <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32> %"69", <2 x i32> %"70", <4 x float> %"71")
-  %"176" = extractelement <4 x float> %"68", i8 0
-  %"177" = extractelement <4 x float> %"68", i8 1
-  %"178" = extractelement <4 x float> %"68", i8 2
-  %"179" = extractelement <4 x float> %"68", i8 3
+  %"175" = extractelement <4 x float> %"68", i8 0
+  %"176" = extractelement <4 x float> %"68", i8 1
+  %"177" = extractelement <4 x float> %"68", i8 2
+  %"178" = extractelement <4 x float> %"68", i8 3
+  store float %"175", ptr addrspace(5) %"113", align 4
   store float %"176", ptr addrspace(5) %"114", align 4
   store float %"177", ptr addrspace(5) %"115", align 4
   store float %"178", ptr addrspace(5) %"116", align 4
-  store float %"179", ptr addrspace(5) %"117", align 4
-  %69 = load i32, ptr addrspace(5) %"106", align 4
-  %70 = load i32, ptr addrspace(5) %"107", align 4
-  %71 = load i32, ptr addrspace(5) %"108", align 4
-  %72 = load i32, ptr addrspace(5) %"109", align 4
+  %69 = load i32, ptr addrspace(5) %"105", align 4
+  %70 = load i32, ptr addrspace(5) %"106", align 4
+  %71 = load i32, ptr addrspace(5) %"107", align 4
+  %72 = load i32, ptr addrspace(5) %"108", align 4
   %73 = insertelement <4 x i32> undef, i32 %69, i8 0
   %74 = insertelement <4 x i32> %73, i32 %70, i8 1
   %75 = insertelement <4 x i32> %74, i32 %71, i8 2
   %"73" = insertelement <4 x i32> %75, i32 %72, i8 3
-  %76 = load i32, ptr addrspace(5) %"112", align 4
-  %77 = load i32, ptr addrspace(5) %"113", align 4
+  %76 = load i32, ptr addrspace(5) %"111", align 4
+  %77 = load i32, ptr addrspace(5) %"112", align 4
   %78 = insertelement <2 x i32> undef, i32 %76, i8 0
   %"74" = insertelement <2 x i32> %78, i32 %77, i8 1
-  %79 = load float, ptr addrspace(5) %"102", align 4
-  %80 = load float, ptr addrspace(5) %"103", align 4
-  %81 = load float, ptr addrspace(5) %"104", align 4
-  %82 = load float, ptr addrspace(5) %"105", align 4
+  %79 = load float, ptr addrspace(5) %"101", align 4
+  %80 = load float, ptr addrspace(5) %"102", align 4
+  %81 = load float, ptr addrspace(5) %"103", align 4
+  %82 = load float, ptr addrspace(5) %"104", align 4
   %83 = insertelement <4 x float> undef, float %79, i8 0
   %84 = insertelement <4 x float> %83, float %80, i8 1
   %85 = insertelement <4 x float> %84, float %81, i8 2
   %"75" = insertelement <4 x float> %85, float %82, i8 3
   %"72" = call <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32> %"73", <2 x i32> %"74", <4 x float> %"75")
-  %"190" = extractelement <4 x float> %"72", i8 0
-  %"191" = extractelement <4 x float> %"72", i8 1
-  %"192" = extractelement <4 x float> %"72", i8 2
-  %"193" = extractelement <4 x float> %"72", i8 3
+  %"189" = extractelement <4 x float> %"72", i8 0
+  %"190" = extractelement <4 x float> %"72", i8 1
+  %"191" = extractelement <4 x float> %"72", i8 2
+  %"192" = extractelement <4 x float> %"72", i8 3
+  store float %"189", ptr addrspace(5) %"117", align 4
   store float %"190", ptr addrspace(5) %"118", align 4
   store float %"191", ptr addrspace(5) %"119", align 4
   store float %"192", ptr addrspace(5) %"120", align 4
-  store float %"193", ptr addrspace(5) %"121", align 4
-  %86 = load i32, ptr addrspace(5) %"97", align 4
-  %"194" = zext i32 %86 to i64
-  store i64 %"194", ptr addrspace(5) %"96", align 8
-  %87 = load i64, ptr addrspace(5) %"96", align 8
-  %"196" = mul i64 %87, 32
-  store i64 %"196", ptr addrspace(5) %"96", align 8
+  %86 = load i32, ptr addrspace(5) %"96", align 4
+  %87 = zext i32 %86 to i64
+  store i64 %87, ptr addrspace(5) %"95", align 8
   %88 = load i64, ptr addrspace(5) %"95", align 8
-  %89 = load i64, ptr addrspace(5) %"96", align 8
-  %"198" = add i64 %88, %89
-  store i64 %"198", ptr addrspace(5) %"95", align 8
+  %"195" = mul i64 %88, 32
+  store i64 %"195", ptr addrspace(5) %"95", align 8
+  %89 = load i64, ptr addrspace(5) %"94", align 8
   %90 = load i64, ptr addrspace(5) %"95", align 8
-  %91 = load float, ptr addrspace(5) %"114", align 4
-  %"237" = inttoptr i64 %90 to ptr
-  store float %91, ptr %"237", align 4
-  %92 = load i64, ptr addrspace(5) %"95", align 8
-  %"238" = inttoptr i64 %92 to ptr
-  %"78" = getelementptr inbounds i8, ptr %"238", i64 4
-  %93 = load float, ptr addrspace(5) %"115", align 4
-  store float %93, ptr %"78", align 4
-  %94 = load i64, ptr addrspace(5) %"95", align 8
-  %"239" = inttoptr i64 %94 to ptr
-  %"80" = getelementptr inbounds i8, ptr %"239", i64 8
-  %95 = load float, ptr addrspace(5) %"116", align 4
-  store float %95, ptr %"80", align 4
-  %96 = load i64, ptr addrspace(5) %"95", align 8
-  %"240" = inttoptr i64 %96 to ptr
-  %"82" = getelementptr inbounds i8, ptr %"240", i64 12
-  %97 = load float, ptr addrspace(5) %"117", align 4
-  store float %97, ptr %"82", align 4
-  %98 = load i64, ptr addrspace(5) %"95", align 8
-  %"241" = inttoptr i64 %98 to ptr
-  %"84" = getelementptr inbounds i8, ptr %"241", i64 16
-  %99 = load float, ptr addrspace(5) %"118", align 4
-  store float %99, ptr %"84", align 4
-  %100 = load i64, ptr addrspace(5) %"95", align 8
-  %"242" = inttoptr i64 %100 to ptr
-  %"86" = getelementptr inbounds i8, ptr %"242", i64 20
-  %101 = load float, ptr addrspace(5) %"119", align 4
-  store float %101, ptr %"86", align 4
-  %102 = load i64, ptr addrspace(5) %"95", align 8
-  %"243" = inttoptr i64 %102 to ptr
-  %"88" = getelementptr inbounds i8, ptr %"243", i64 24
-  %103 = load float, ptr addrspace(5) %"120", align 4
-  store float %103, ptr %"88", align 4
-  %104 = load i64, ptr addrspace(5) %"95", align 8
-  %"244" = inttoptr i64 %104 to ptr
-  %"90" = getelementptr inbounds i8, ptr %"244", i64 28
-  %105 = load float, ptr addrspace(5) %"121", align 4
-  store float %105, ptr %"90", align 4
+  %"197" = add i64 %89, %90
+  store i64 %"197", ptr addrspace(5) %"94", align 8
+  %91 = load i64, ptr addrspace(5) %"94", align 8
+  %92 = load float, ptr addrspace(5) %"113", align 4
+  %"236" = inttoptr i64 %91 to ptr
+  store float %92, ptr %"236", align 4
+  %93 = load i64, ptr addrspace(5) %"94", align 8
+  %"237" = inttoptr i64 %93 to ptr
+  %"78" = getelementptr inbounds i8, ptr %"237", i64 4
+  %94 = load float, ptr addrspace(5) %"114", align 4
+  store float %94, ptr %"78", align 4
+  %95 = load i64, ptr addrspace(5) %"94", align 8
+  %"238" = inttoptr i64 %95 to ptr
+  %"80" = getelementptr inbounds i8, ptr %"238", i64 8
+  %96 = load float, ptr addrspace(5) %"115", align 4
+  store float %96, ptr %"80", align 4
+  %97 = load i64, ptr addrspace(5) %"94", align 8
+  %"239" = inttoptr i64 %97 to ptr
+  %"82" = getelementptr inbounds i8, ptr %"239", i64 12
+  %98 = load float, ptr addrspace(5) %"116", align 4
+  store float %98, ptr %"82", align 4
+  %99 = load i64, ptr addrspace(5) %"94", align 8
+  %"240" = inttoptr i64 %99 to ptr
+  %"84" = getelementptr inbounds i8, ptr %"240", i64 16
+  %100 = load float, ptr addrspace(5) %"117", align 4
+  store float %100, ptr %"84", align 4
+  %101 = load i64, ptr addrspace(5) %"94", align 8
+  %"241" = inttoptr i64 %101 to ptr
+  %"86" = getelementptr inbounds i8, ptr %"241", i64 20
+  %102 = load float, ptr addrspace(5) %"118", align 4
+  store float %102, ptr %"86", align 4
+  %103 = load i64, ptr addrspace(5) %"94", align 8
+  %"242" = inttoptr i64 %103 to ptr
+  %"88" = getelementptr inbounds i8, ptr %"242", i64 24
+  %104 = load float, ptr addrspace(5) %"119", align 4
+  store float %104, ptr %"88", align 4
+  %105 = load i64, ptr addrspace(5) %"94", align 8
+  %"243" = inttoptr i64 %105 to ptr
+  %"90" = getelementptr inbounds i8, ptr %"243", i64 28
+  %106 = load float, ptr addrspace(5) %"120", align 4
+  store float %106, ptr %"90", align 4
   ret void
 }
 
-declare <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32>, <2 x i32>, <4 x float>)
+; Function Attrs: convergent nocallback nofree nosync nounwind willreturn memory(none)
+declare <4 x float> @llvm.zluda.mma.m16n8k16(<4 x i32>, <2 x i32>, <4 x float>) #2
 
 attributes #0 = { "amdgpu-ieee"="false" "amdgpu-unsafe-fp-atomics"="true" "denormal-fp-math"="dynamic" "denormal-fp-math-f32"="dynamic" "no-trapping-math"="true" "uniform-work-group-size"="true" }
 attributes #1 = { "amdgpu-ieee"="false" "amdgpu-unsafe-fp-atomics"="true" "denormal-fp-math"="ieee" "denormal-fp-math-f32"="ieee" "no-trapping-math"="true" "uniform-work-group-size"="true" }
+attributes #2 = { convergent nocallback nofree nosync nounwind willreturn memory(none) }

--- a/ptx/src/test/ll/ntid.ll
+++ b/ptx/src/test/ll/ntid.ll
@@ -1,37 +1,34 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_ntid(i8) #0
 
-define amdgpu_kernel void @ntid(ptr addrspace(4) byref(i64) %"41", ptr addrspace(4) byref(i64) %"42") #1 {
+define amdgpu_kernel void @ntid(ptr addrspace(4) byref(i64) %"40", ptr addrspace(4) byref(i64) %"41") #1 {
+  %"42" = alloca i64, align 8, addrspace(5)
   %"43" = alloca i64, align 8, addrspace(5)
-  %"44" = alloca i64, align 8, addrspace(5)
+  %"44" = alloca i32, align 4, addrspace(5)
   %"45" = alloca i32, align 4, addrspace(5)
-  %"46" = alloca i32, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"38"
 
 "38":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"41", align 8
-  store i64 %2, ptr addrspace(5) %"43", align 8
-  %3 = load i64, ptr addrspace(4) %"42", align 8
-  store i64 %3, ptr addrspace(5) %"44", align 8
-  %4 = load i64, ptr addrspace(5) %"43", align 8
-  %"57" = inttoptr i64 %4 to ptr
-  %5 = load i32, ptr %"57", align 4
-  store i32 %5, ptr addrspace(5) %"45", align 4
+  %2 = load i64, ptr addrspace(4) %"40", align 8
+  store i64 %2, ptr addrspace(5) %"42", align 8
+  %3 = load i64, ptr addrspace(4) %"41", align 8
+  store i64 %3, ptr addrspace(5) %"43", align 8
+  %4 = load i64, ptr addrspace(5) %"42", align 8
+  %"56" = inttoptr i64 %4 to ptr
+  %5 = load i32, ptr %"56", align 4
+  store i32 %5, ptr addrspace(5) %"44", align 4
   %"37" = call i32 @__zluda_ptx_impl_sreg_ntid(i8 0)
-  br label %"39"
-
-"39":                                             ; preds = %"38"
-  store i32 %"37", ptr addrspace(5) %"46", align 4
-  %6 = load i32, ptr addrspace(5) %"45", align 4
-  %7 = load i32, ptr addrspace(5) %"46", align 4
-  %"52" = add i32 %6, %7
-  store i32 %"52", ptr addrspace(5) %"45", align 4
-  %8 = load i64, ptr addrspace(5) %"44", align 8
-  %9 = load i32, ptr addrspace(5) %"45", align 4
-  %"58" = inttoptr i64 %8 to ptr
-  store i32 %9, ptr %"58", align 4
+  store i32 %"37", ptr addrspace(5) %"45", align 4
+  %6 = load i32, ptr addrspace(5) %"44", align 4
+  %7 = load i32, ptr addrspace(5) %"45", align 4
+  %"51" = add i32 %6, %7
+  store i32 %"51", ptr addrspace(5) %"44", align 4
+  %8 = load i64, ptr addrspace(5) %"43", align 8
+  %9 = load i32, ptr addrspace(5) %"44", align 4
+  %"57" = inttoptr i64 %8 to ptr
+  store i32 %9, ptr %"57", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/redux_sync_add_u32_partial.ll
+++ b/ptx/src/test/ll/redux_sync_add_u32_partial.ll
@@ -2,55 +2,52 @@ declare hidden i32 @__zluda_ptx_impl_redux_sync_add_u32(i32, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @redux_sync_add_u32_partial(ptr addrspace(4) byref(i64) %"49") #1 {
+define amdgpu_kernel void @redux_sync_add_u32_partial(ptr addrspace(4) byref(i64) %"48") #1 {
+  %"49" = alloca i32, align 4, addrspace(5)
   %"50" = alloca i32, align 4, addrspace(5)
-  %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i64, align 8, addrspace(5)
-  %"53" = alloca i32, align 4, addrspace(5)
-  %"54" = alloca i1, align 1, addrspace(5)
-  %"65" = alloca i64, align 8, addrspace(5)
+  %"51" = alloca i64, align 8, addrspace(5)
+  %"52" = alloca i32, align 4, addrspace(5)
+  %"53" = alloca i1, align 1, addrspace(5)
+  %"64" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"46"
 
 "46":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"49", align 8
-  store i64 %2, ptr addrspace(5) %"52", align 8
+  %2 = load i64, ptr addrspace(4) %"48", align 8
+  store i64 %2, ptr addrspace(5) %"51", align 8
   %"40" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"47"
-
-"47":                                             ; preds = %"46"
-  store i32 %"40", ptr addrspace(5) %"50", align 4
-  %3 = load i32, ptr addrspace(5) %"50", align 4
-  %"57" = urem i32 %3, 2
-  store i32 %"57", ptr addrspace(5) %"53", align 4
-  %4 = load i32, ptr addrspace(5) %"53", align 4
+  store i32 %"40", ptr addrspace(5) %"49", align 4
+  %3 = load i32, ptr addrspace(5) %"49", align 4
+  %"56" = urem i32 %3, 2
+  store i32 %"56", ptr addrspace(5) %"52", align 4
+  %4 = load i32, ptr addrspace(5) %"52", align 4
   %5 = icmp eq i32 %4, 0
-  store i1 %5, ptr addrspace(5) %"54", align 1
-  store i32 0, ptr addrspace(5) %"51", align 4
-  %6 = load i1, ptr addrspace(5) %"54", align 1
+  store i1 %5, ptr addrspace(5) %"53", align 1
+  store i32 0, ptr addrspace(5) %"50", align 4
+  %6 = load i1, ptr addrspace(5) %"53", align 1
   br i1 %6, label %"17", label %"18"
 
-"17":                                             ; preds = %"47"
-  %7 = load i32, ptr addrspace(5) %"50", align 4
-  %"63" = call i32 @__zluda_ptx_impl_redux_sync_add_u32(i32 %7, i32 1431655765)
-  store i32 %"63", ptr addrspace(5) %"51", align 4
+"17":                                             ; preds = %"46"
+  %7 = load i32, ptr addrspace(5) %"49", align 4
+  %"62" = call i32 @__zluda_ptx_impl_redux_sync_add_u32(i32 %7, i32 1431655765)
+  store i32 %"62", ptr addrspace(5) %"50", align 4
   br label %"18"
 
-"18":                                             ; preds = %"17", %"47"
-  %8 = load i32, ptr addrspace(5) %"50", align 4
+"18":                                             ; preds = %"17", %"46"
+  %8 = load i32, ptr addrspace(5) %"49", align 4
   %9 = zext i32 %8 to i64
-  %"66" = mul i64 %9, 4
-  store i64 %"66", ptr addrspace(5) %"65", align 8
-  %10 = load i64, ptr addrspace(5) %"52", align 8
-  %11 = load i64, ptr addrspace(5) %"65", align 8
-  %"68" = add i64 %10, %11
-  store i64 %"68", ptr addrspace(5) %"52", align 8
-  %12 = load i64, ptr addrspace(5) %"52", align 8
-  %13 = load i32, ptr addrspace(5) %"51", align 4
-  %"73" = inttoptr i64 %12 to ptr
-  store i32 %13, ptr %"73", align 4
+  %"65" = mul i64 %9, 4
+  store i64 %"65", ptr addrspace(5) %"64", align 8
+  %10 = load i64, ptr addrspace(5) %"51", align 8
+  %11 = load i64, ptr addrspace(5) %"64", align 8
+  %"67" = add i64 %10, %11
+  store i64 %"67", ptr addrspace(5) %"51", align 8
+  %12 = load i64, ptr addrspace(5) %"51", align 8
+  %13 = load i32, ptr addrspace(5) %"50", align 4
+  %"72" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"72", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/redux_sync_op_s32.ll
+++ b/ptx/src/test/ll/redux_sync_op_s32.ll
@@ -6,60 +6,57 @@ declare hidden i32 @__zluda_ptx_impl_redux_sync_min_s32(i32, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @redux_sync_op_s32(ptr addrspace(4) byref(i64) %"49") #1 {
+define amdgpu_kernel void @redux_sync_op_s32(ptr addrspace(4) byref(i64) %"48") #1 {
+  %"49" = alloca i32, align 4, addrspace(5)
   %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
   %"52" = alloca i32, align 4, addrspace(5)
   %"53" = alloca i32, align 4, addrspace(5)
   %"54" = alloca i32, align 4, addrspace(5)
-  %"55" = alloca i32, align 4, addrspace(5)
-  %"56" = alloca i64, align 8, addrspace(5)
-  %"73" = alloca i64, align 8, addrspace(5)
+  %"55" = alloca i64, align 8, addrspace(5)
+  %"72" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"46"
 
 "46":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"49", align 8
-  store i64 %2, ptr addrspace(5) %"56", align 8
+  %2 = load i64, ptr addrspace(4) %"48", align 8
+  store i64 %2, ptr addrspace(5) %"55", align 8
   %"40" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"47"
-
-"47":                                             ; preds = %"46"
-  store i32 %"40", ptr addrspace(5) %"50", align 4
-  %3 = load i32, ptr addrspace(5) %"50", align 4
-  %"59" = sub i32 %3, 5
-  store i32 %"59", ptr addrspace(5) %"51", align 4
-  %4 = load i32, ptr addrspace(5) %"51", align 4
-  %"61" = call i32 @__zluda_ptx_impl_redux_sync_add_s32(i32 %4, i32 -1)
-  store i32 %"61", ptr addrspace(5) %"52", align 4
-  %5 = load i32, ptr addrspace(5) %"51", align 4
-  %"63" = call i32 @__zluda_ptx_impl_redux_sync_min_s32(i32 %5, i32 -1)
-  store i32 %"63", ptr addrspace(5) %"53", align 4
-  %6 = load i32, ptr addrspace(5) %"51", align 4
-  %"65" = call i32 @__zluda_ptx_impl_redux_sync_max_s32(i32 %6, i32 -1)
-  store i32 %"65", ptr addrspace(5) %"54", align 4
-  %7 = load i32, ptr addrspace(5) %"52", align 4
-  %8 = load i32, ptr addrspace(5) %"53", align 4
-  %"67" = add i32 %7, %8
-  store i32 %"67", ptr addrspace(5) %"55", align 4
-  %9 = load i32, ptr addrspace(5) %"55", align 4
-  %10 = load i32, ptr addrspace(5) %"54", align 4
-  %"70" = add i32 %9, %10
-  store i32 %"70", ptr addrspace(5) %"55", align 4
-  %11 = load i32, ptr addrspace(5) %"50", align 4
+  store i32 %"40", ptr addrspace(5) %"49", align 4
+  %3 = load i32, ptr addrspace(5) %"49", align 4
+  %"58" = sub i32 %3, 5
+  store i32 %"58", ptr addrspace(5) %"50", align 4
+  %4 = load i32, ptr addrspace(5) %"50", align 4
+  %"60" = call i32 @__zluda_ptx_impl_redux_sync_add_s32(i32 %4, i32 -1)
+  store i32 %"60", ptr addrspace(5) %"51", align 4
+  %5 = load i32, ptr addrspace(5) %"50", align 4
+  %"62" = call i32 @__zluda_ptx_impl_redux_sync_min_s32(i32 %5, i32 -1)
+  store i32 %"62", ptr addrspace(5) %"52", align 4
+  %6 = load i32, ptr addrspace(5) %"50", align 4
+  %"64" = call i32 @__zluda_ptx_impl_redux_sync_max_s32(i32 %6, i32 -1)
+  store i32 %"64", ptr addrspace(5) %"53", align 4
+  %7 = load i32, ptr addrspace(5) %"51", align 4
+  %8 = load i32, ptr addrspace(5) %"52", align 4
+  %"66" = add i32 %7, %8
+  store i32 %"66", ptr addrspace(5) %"54", align 4
+  %9 = load i32, ptr addrspace(5) %"54", align 4
+  %10 = load i32, ptr addrspace(5) %"53", align 4
+  %"69" = add i32 %9, %10
+  store i32 %"69", ptr addrspace(5) %"54", align 4
+  %11 = load i32, ptr addrspace(5) %"49", align 4
   %12 = zext i32 %11 to i64
-  %"74" = mul i64 %12, 4
-  store i64 %"74", ptr addrspace(5) %"73", align 8
-  %13 = load i64, ptr addrspace(5) %"56", align 8
-  %14 = load i64, ptr addrspace(5) %"73", align 8
-  %"76" = add i64 %13, %14
-  store i64 %"76", ptr addrspace(5) %"56", align 8
-  %15 = load i64, ptr addrspace(5) %"56", align 8
-  %16 = load i32, ptr addrspace(5) %"55", align 4
-  %"82" = inttoptr i64 %15 to ptr
-  store i32 %16, ptr %"82", align 4
+  %"73" = mul i64 %12, 4
+  store i64 %"73", ptr addrspace(5) %"72", align 8
+  %13 = load i64, ptr addrspace(5) %"55", align 8
+  %14 = load i64, ptr addrspace(5) %"72", align 8
+  %"75" = add i64 %13, %14
+  store i64 %"75", ptr addrspace(5) %"55", align 8
+  %15 = load i64, ptr addrspace(5) %"55", align 8
+  %16 = load i32, ptr addrspace(5) %"54", align 4
+  %"81" = inttoptr i64 %15 to ptr
+  store i32 %16, ptr %"81", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/redux_sync_op_u32.ll
+++ b/ptx/src/test/ll/redux_sync_op_u32.ll
@@ -6,56 +6,53 @@ declare hidden i32 @__zluda_ptx_impl_redux_sync_min_u32(i32, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @redux_sync_op_u32(ptr addrspace(4) byref(i64) %"47") #1 {
+define amdgpu_kernel void @redux_sync_op_u32(ptr addrspace(4) byref(i64) %"46") #1 {
+  %"47" = alloca i32, align 4, addrspace(5)
   %"48" = alloca i32, align 4, addrspace(5)
   %"49" = alloca i32, align 4, addrspace(5)
   %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i32, align 4, addrspace(5)
-  %"53" = alloca i64, align 8, addrspace(5)
-  %"68" = alloca i64, align 8, addrspace(5)
+  %"52" = alloca i64, align 8, addrspace(5)
+  %"67" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"44"
 
 "44":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"47", align 8
-  store i64 %2, ptr addrspace(5) %"53", align 8
+  %2 = load i64, ptr addrspace(4) %"46", align 8
+  store i64 %2, ptr addrspace(5) %"52", align 8
   %"39" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"45"
-
-"45":                                             ; preds = %"44"
-  store i32 %"39", ptr addrspace(5) %"48", align 4
-  %3 = load i32, ptr addrspace(5) %"48", align 4
-  %"56" = call i32 @__zluda_ptx_impl_redux_sync_add_u32(i32 %3, i32 -1)
-  store i32 %"56", ptr addrspace(5) %"49", align 4
-  %4 = load i32, ptr addrspace(5) %"48", align 4
-  %"58" = call i32 @__zluda_ptx_impl_redux_sync_min_u32(i32 %4, i32 -1)
-  store i32 %"58", ptr addrspace(5) %"50", align 4
-  %5 = load i32, ptr addrspace(5) %"48", align 4
-  %"60" = call i32 @__zluda_ptx_impl_redux_sync_max_u32(i32 %5, i32 -1)
-  store i32 %"60", ptr addrspace(5) %"51", align 4
-  %6 = load i32, ptr addrspace(5) %"49", align 4
-  %7 = load i32, ptr addrspace(5) %"50", align 4
-  %"62" = add i32 %6, %7
-  store i32 %"62", ptr addrspace(5) %"52", align 4
-  %8 = load i32, ptr addrspace(5) %"52", align 4
-  %9 = load i32, ptr addrspace(5) %"51", align 4
-  %"65" = add i32 %8, %9
-  store i32 %"65", ptr addrspace(5) %"52", align 4
-  %10 = load i32, ptr addrspace(5) %"48", align 4
+  store i32 %"39", ptr addrspace(5) %"47", align 4
+  %3 = load i32, ptr addrspace(5) %"47", align 4
+  %"55" = call i32 @__zluda_ptx_impl_redux_sync_add_u32(i32 %3, i32 -1)
+  store i32 %"55", ptr addrspace(5) %"48", align 4
+  %4 = load i32, ptr addrspace(5) %"47", align 4
+  %"57" = call i32 @__zluda_ptx_impl_redux_sync_min_u32(i32 %4, i32 -1)
+  store i32 %"57", ptr addrspace(5) %"49", align 4
+  %5 = load i32, ptr addrspace(5) %"47", align 4
+  %"59" = call i32 @__zluda_ptx_impl_redux_sync_max_u32(i32 %5, i32 -1)
+  store i32 %"59", ptr addrspace(5) %"50", align 4
+  %6 = load i32, ptr addrspace(5) %"48", align 4
+  %7 = load i32, ptr addrspace(5) %"49", align 4
+  %"61" = add i32 %6, %7
+  store i32 %"61", ptr addrspace(5) %"51", align 4
+  %8 = load i32, ptr addrspace(5) %"51", align 4
+  %9 = load i32, ptr addrspace(5) %"50", align 4
+  %"64" = add i32 %8, %9
+  store i32 %"64", ptr addrspace(5) %"51", align 4
+  %10 = load i32, ptr addrspace(5) %"47", align 4
   %11 = zext i32 %10 to i64
-  %"69" = mul i64 %11, 4
-  store i64 %"69", ptr addrspace(5) %"68", align 8
-  %12 = load i64, ptr addrspace(5) %"53", align 8
-  %13 = load i64, ptr addrspace(5) %"68", align 8
-  %"71" = add i64 %12, %13
-  store i64 %"71", ptr addrspace(5) %"53", align 8
-  %14 = load i64, ptr addrspace(5) %"53", align 8
-  %15 = load i32, ptr addrspace(5) %"52", align 4
-  %"76" = inttoptr i64 %14 to ptr
-  store i32 %15, ptr %"76", align 4
+  %"68" = mul i64 %11, 4
+  store i64 %"68", ptr addrspace(5) %"67", align 8
+  %12 = load i64, ptr addrspace(5) %"52", align 8
+  %13 = load i64, ptr addrspace(5) %"67", align 8
+  %"70" = add i64 %12, %13
+  store i64 %"70", ptr addrspace(5) %"52", align 8
+  %14 = load i64, ptr addrspace(5) %"52", align 8
+  %15 = load i32, ptr addrspace(5) %"51", align 4
+  %"75" = inttoptr i64 %14 to ptr
+  store i32 %15, ptr %"75", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/shfl_sync_bfly_b32_pred.ll
+++ b/ptx/src/test/ll/shfl_sync_bfly_b32_pred.ll
@@ -2,56 +2,53 @@ declare hidden <2 x i32> @__zluda_ptx_impl_shfl_sync_bfly_b32_pred(i32, i32, i32
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @shfl_sync_bfly_b32_pred(ptr addrspace(4) byref(i64) %"48") #1 {
+define amdgpu_kernel void @shfl_sync_bfly_b32_pred(ptr addrspace(4) byref(i64) %"47") #1 {
+  %"48" = alloca i64, align 8, addrspace(5)
   %"49" = alloca i64, align 8, addrspace(5)
-  %"50" = alloca i64, align 8, addrspace(5)
+  %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i32, align 4, addrspace(5)
-  %"53" = alloca i1, align 1, addrspace(5)
+  %"52" = alloca i1, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"45"
 
 "45":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"48", align 8
-  store i64 %2, ptr addrspace(5) %"49", align 8
+  %2 = load i64, ptr addrspace(4) %"47", align 8
+  store i64 %2, ptr addrspace(5) %"48", align 8
   %"39" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"46"
+  store i32 %"39", ptr addrspace(5) %"50", align 4
+  %3 = load i32, ptr addrspace(5) %"50", align 4
+  %"73" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_bfly_b32_pred(i32 %3, i32 3, i32 31, i32 -1)
+  %"70" = extractelement <2 x i32> %"73", i8 0
+  %"74" = extractelement <2 x i32> %"73", i8 1
+  %4 = trunc i32 %"74" to i1
+  store i32 %"70", ptr addrspace(5) %"51", align 4
+  store i1 %4, ptr addrspace(5) %"52", align 1
+  %5 = load i1, ptr addrspace(5) %"52", align 1
+  br i1 %5, label %"17", label %"16"
 
-"46":                                             ; preds = %"45"
-  store i32 %"39", ptr addrspace(5) %"51", align 4
-  %3 = load i32, ptr addrspace(5) %"51", align 4
-  %"74" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_bfly_b32_pred(i32 %3, i32 3, i32 31, i32 -1)
-  %"71" = extractelement <2 x i32> %"74", i8 0
-  %"75" = extractelement <2 x i32> %"74", i8 1
-  %"57" = trunc i32 %"75" to i1
-  store i32 %"71", ptr addrspace(5) %"52", align 4
-  store i1 %"57", ptr addrspace(5) %"53", align 1
-  %4 = load i1, ptr addrspace(5) %"53", align 1
-  br i1 %4, label %"17", label %"16"
-
-"16":                                             ; preds = %"46"
-  %5 = load i32, ptr addrspace(5) %"52", align 4
-  %"60" = add i32 %5, 1000
-  store i32 %"60", ptr addrspace(5) %"52", align 4
+"16":                                             ; preds = %"45"
+  %6 = load i32, ptr addrspace(5) %"51", align 4
+  %"59" = add i32 %6, 1000
+  store i32 %"59", ptr addrspace(5) %"51", align 4
   br label %"17"
 
-"17":                                             ; preds = %"16", %"46"
-  %6 = load i32, ptr addrspace(5) %"51", align 4
-  %"62" = zext i32 %6 to i64
-  store i64 %"62", ptr addrspace(5) %"50", align 8
-  %7 = load i64, ptr addrspace(5) %"50", align 8
-  %"64" = mul i64 %7, 4
-  store i64 %"64", ptr addrspace(5) %"50", align 8
-  %8 = load i64, ptr addrspace(5) %"49", align 8
-  %9 = load i64, ptr addrspace(5) %"50", align 8
-  %"66" = add i64 %8, %9
-  store i64 %"66", ptr addrspace(5) %"49", align 8
-  %10 = load i64, ptr addrspace(5) %"49", align 8
-  %11 = load i32, ptr addrspace(5) %"52", align 4
-  %"73" = inttoptr i64 %10 to ptr
-  store i32 %11, ptr %"73", align 4
+"17":                                             ; preds = %"16", %"45"
+  %7 = load i32, ptr addrspace(5) %"50", align 4
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr addrspace(5) %"49", align 8
+  %9 = load i64, ptr addrspace(5) %"49", align 8
+  %"63" = mul i64 %9, 4
+  store i64 %"63", ptr addrspace(5) %"49", align 8
+  %10 = load i64, ptr addrspace(5) %"48", align 8
+  %11 = load i64, ptr addrspace(5) %"49", align 8
+  %"65" = add i64 %10, %11
+  store i64 %"65", ptr addrspace(5) %"48", align 8
+  %12 = load i64, ptr addrspace(5) %"48", align 8
+  %13 = load i32, ptr addrspace(5) %"51", align 4
+  %"72" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"72", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/shfl_sync_down_b32_pred.ll
+++ b/ptx/src/test/ll/shfl_sync_down_b32_pred.ll
@@ -2,56 +2,53 @@ declare hidden <2 x i32> @__zluda_ptx_impl_shfl_sync_down_b32_pred(i32, i32, i32
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @shfl_sync_down_b32_pred(ptr addrspace(4) byref(i64) %"48") #1 {
+define amdgpu_kernel void @shfl_sync_down_b32_pred(ptr addrspace(4) byref(i64) %"47") #1 {
+  %"48" = alloca i64, align 8, addrspace(5)
   %"49" = alloca i64, align 8, addrspace(5)
-  %"50" = alloca i64, align 8, addrspace(5)
+  %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i32, align 4, addrspace(5)
-  %"53" = alloca i1, align 1, addrspace(5)
+  %"52" = alloca i1, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"45"
 
 "45":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"48", align 8
-  store i64 %2, ptr addrspace(5) %"49", align 8
+  %2 = load i64, ptr addrspace(4) %"47", align 8
+  store i64 %2, ptr addrspace(5) %"48", align 8
   %"39" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"46"
+  store i32 %"39", ptr addrspace(5) %"50", align 4
+  %3 = load i32, ptr addrspace(5) %"50", align 4
+  %"73" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_down_b32_pred(i32 %3, i32 3, i32 31, i32 -1)
+  %"70" = extractelement <2 x i32> %"73", i8 0
+  %"74" = extractelement <2 x i32> %"73", i8 1
+  %4 = trunc i32 %"74" to i1
+  store i32 %"70", ptr addrspace(5) %"51", align 4
+  store i1 %4, ptr addrspace(5) %"52", align 1
+  %5 = load i1, ptr addrspace(5) %"52", align 1
+  br i1 %5, label %"17", label %"16"
 
-"46":                                             ; preds = %"45"
-  store i32 %"39", ptr addrspace(5) %"51", align 4
-  %3 = load i32, ptr addrspace(5) %"51", align 4
-  %"74" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_down_b32_pred(i32 %3, i32 3, i32 31, i32 -1)
-  %"71" = extractelement <2 x i32> %"74", i8 0
-  %"75" = extractelement <2 x i32> %"74", i8 1
-  %"57" = trunc i32 %"75" to i1
-  store i32 %"71", ptr addrspace(5) %"52", align 4
-  store i1 %"57", ptr addrspace(5) %"53", align 1
-  %4 = load i1, ptr addrspace(5) %"53", align 1
-  br i1 %4, label %"17", label %"16"
-
-"16":                                             ; preds = %"46"
-  %5 = load i32, ptr addrspace(5) %"52", align 4
-  %"60" = add i32 %5, 1000
-  store i32 %"60", ptr addrspace(5) %"52", align 4
+"16":                                             ; preds = %"45"
+  %6 = load i32, ptr addrspace(5) %"51", align 4
+  %"59" = add i32 %6, 1000
+  store i32 %"59", ptr addrspace(5) %"51", align 4
   br label %"17"
 
-"17":                                             ; preds = %"16", %"46"
-  %6 = load i32, ptr addrspace(5) %"51", align 4
-  %"62" = zext i32 %6 to i64
-  store i64 %"62", ptr addrspace(5) %"50", align 8
-  %7 = load i64, ptr addrspace(5) %"50", align 8
-  %"64" = mul i64 %7, 4
-  store i64 %"64", ptr addrspace(5) %"50", align 8
-  %8 = load i64, ptr addrspace(5) %"49", align 8
-  %9 = load i64, ptr addrspace(5) %"50", align 8
-  %"66" = add i64 %8, %9
-  store i64 %"66", ptr addrspace(5) %"49", align 8
-  %10 = load i64, ptr addrspace(5) %"49", align 8
-  %11 = load i32, ptr addrspace(5) %"52", align 4
-  %"73" = inttoptr i64 %10 to ptr
-  store i32 %11, ptr %"73", align 4
+"17":                                             ; preds = %"16", %"45"
+  %7 = load i32, ptr addrspace(5) %"50", align 4
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr addrspace(5) %"49", align 8
+  %9 = load i64, ptr addrspace(5) %"49", align 8
+  %"63" = mul i64 %9, 4
+  store i64 %"63", ptr addrspace(5) %"49", align 8
+  %10 = load i64, ptr addrspace(5) %"48", align 8
+  %11 = load i64, ptr addrspace(5) %"49", align 8
+  %"65" = add i64 %10, %11
+  store i64 %"65", ptr addrspace(5) %"48", align 8
+  %12 = load i64, ptr addrspace(5) %"48", align 8
+  %13 = load i32, ptr addrspace(5) %"51", align 4
+  %"72" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"72", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/shfl_sync_idx_b32_pred.ll
+++ b/ptx/src/test/ll/shfl_sync_idx_b32_pred.ll
@@ -2,56 +2,53 @@ declare hidden <2 x i32> @__zluda_ptx_impl_shfl_sync_idx_b32_pred(i32, i32, i32,
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @shfl_sync_idx_b32_pred(ptr addrspace(4) byref(i64) %"48") #1 {
+define amdgpu_kernel void @shfl_sync_idx_b32_pred(ptr addrspace(4) byref(i64) %"47") #1 {
+  %"48" = alloca i64, align 8, addrspace(5)
   %"49" = alloca i64, align 8, addrspace(5)
-  %"50" = alloca i64, align 8, addrspace(5)
+  %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i32, align 4, addrspace(5)
-  %"53" = alloca i1, align 1, addrspace(5)
+  %"52" = alloca i1, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"45"
 
 "45":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"48", align 8
-  store i64 %2, ptr addrspace(5) %"49", align 8
+  %2 = load i64, ptr addrspace(4) %"47", align 8
+  store i64 %2, ptr addrspace(5) %"48", align 8
   %"39" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"46"
+  store i32 %"39", ptr addrspace(5) %"50", align 4
+  %3 = load i32, ptr addrspace(5) %"50", align 4
+  %"73" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_idx_b32_pred(i32 %3, i32 12, i32 31, i32 -1)
+  %"70" = extractelement <2 x i32> %"73", i8 0
+  %"74" = extractelement <2 x i32> %"73", i8 1
+  %4 = trunc i32 %"74" to i1
+  store i32 %"70", ptr addrspace(5) %"51", align 4
+  store i1 %4, ptr addrspace(5) %"52", align 1
+  %5 = load i1, ptr addrspace(5) %"52", align 1
+  br i1 %5, label %"17", label %"16"
 
-"46":                                             ; preds = %"45"
-  store i32 %"39", ptr addrspace(5) %"51", align 4
-  %3 = load i32, ptr addrspace(5) %"51", align 4
-  %"74" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_idx_b32_pred(i32 %3, i32 12, i32 31, i32 -1)
-  %"71" = extractelement <2 x i32> %"74", i8 0
-  %"75" = extractelement <2 x i32> %"74", i8 1
-  %"57" = trunc i32 %"75" to i1
-  store i32 %"71", ptr addrspace(5) %"52", align 4
-  store i1 %"57", ptr addrspace(5) %"53", align 1
-  %4 = load i1, ptr addrspace(5) %"53", align 1
-  br i1 %4, label %"17", label %"16"
-
-"16":                                             ; preds = %"46"
-  %5 = load i32, ptr addrspace(5) %"52", align 4
-  %"60" = add i32 %5, 1000
-  store i32 %"60", ptr addrspace(5) %"52", align 4
+"16":                                             ; preds = %"45"
+  %6 = load i32, ptr addrspace(5) %"51", align 4
+  %"59" = add i32 %6, 1000
+  store i32 %"59", ptr addrspace(5) %"51", align 4
   br label %"17"
 
-"17":                                             ; preds = %"16", %"46"
-  %6 = load i32, ptr addrspace(5) %"51", align 4
-  %"62" = zext i32 %6 to i64
-  store i64 %"62", ptr addrspace(5) %"50", align 8
-  %7 = load i64, ptr addrspace(5) %"50", align 8
-  %"64" = mul i64 %7, 4
-  store i64 %"64", ptr addrspace(5) %"50", align 8
-  %8 = load i64, ptr addrspace(5) %"49", align 8
-  %9 = load i64, ptr addrspace(5) %"50", align 8
-  %"66" = add i64 %8, %9
-  store i64 %"66", ptr addrspace(5) %"49", align 8
-  %10 = load i64, ptr addrspace(5) %"49", align 8
-  %11 = load i32, ptr addrspace(5) %"52", align 4
-  %"73" = inttoptr i64 %10 to ptr
-  store i32 %11, ptr %"73", align 4
+"17":                                             ; preds = %"16", %"45"
+  %7 = load i32, ptr addrspace(5) %"50", align 4
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr addrspace(5) %"49", align 8
+  %9 = load i64, ptr addrspace(5) %"49", align 8
+  %"63" = mul i64 %9, 4
+  store i64 %"63", ptr addrspace(5) %"49", align 8
+  %10 = load i64, ptr addrspace(5) %"48", align 8
+  %11 = load i64, ptr addrspace(5) %"49", align 8
+  %"65" = add i64 %10, %11
+  store i64 %"65", ptr addrspace(5) %"48", align 8
+  %12 = load i64, ptr addrspace(5) %"48", align 8
+  %13 = load i32, ptr addrspace(5) %"51", align 4
+  %"72" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"72", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/shfl_sync_mode_b32.ll
+++ b/ptx/src/test/ll/shfl_sync_mode_b32.ll
@@ -8,65 +8,62 @@ declare hidden i32 @__zluda_ptx_impl_shfl_sync_up_b32(i32, i32, i32, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @shfl_sync_mode_b32(ptr addrspace(4) byref(i64) %"54") #1 {
+define amdgpu_kernel void @shfl_sync_mode_b32(ptr addrspace(4) byref(i64) %"53") #1 {
+  %"54" = alloca i64, align 8, addrspace(5)
   %"55" = alloca i64, align 8, addrspace(5)
-  %"56" = alloca i64, align 8, addrspace(5)
+  %"56" = alloca i32, align 4, addrspace(5)
   %"57" = alloca i32, align 4, addrspace(5)
   %"58" = alloca i32, align 4, addrspace(5)
-  %"59" = alloca i32, align 4, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"51"
 
 "51":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"54", align 8
-  store i64 %2, ptr addrspace(5) %"55", align 8
+  %2 = load i64, ptr addrspace(4) %"53", align 8
+  store i64 %2, ptr addrspace(5) %"54", align 8
   %"37" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"52"
-
-"52":                                             ; preds = %"51"
-  store i32 %"37", ptr addrspace(5) %"57", align 4
-  %3 = load i32, ptr addrspace(5) %"57", align 4
-  %"90" = call i32 @__zluda_ptx_impl_shfl_sync_up_b32(i32 %3, i32 3, i32 7680, i32 -1)
-  store i32 %"90", ptr addrspace(5) %"58", align 4
-  %4 = load i32, ptr addrspace(5) %"58", align 4
-  store i32 %4, ptr addrspace(5) %"59", align 4
-  %5 = load i32, ptr addrspace(5) %"57", align 4
-  %"92" = call i32 @__zluda_ptx_impl_shfl_sync_down_b32(i32 %5, i32 3, i32 7199, i32 -1)
-  store i32 %"92", ptr addrspace(5) %"58", align 4
-  %6 = load i32, ptr addrspace(5) %"59", align 4
-  %7 = load i32, ptr addrspace(5) %"58", align 4
-  %"68" = add i32 %6, %7
-  store i32 %"68", ptr addrspace(5) %"59", align 4
-  %8 = load i32, ptr addrspace(5) %"57", align 4
-  %"94" = call i32 @__zluda_ptx_impl_shfl_sync_bfly_b32(i32 %8, i32 3, i32 6175, i32 -1)
-  store i32 %"94", ptr addrspace(5) %"58", align 4
-  %9 = load i32, ptr addrspace(5) %"59", align 4
-  %10 = load i32, ptr addrspace(5) %"58", align 4
-  %"73" = add i32 %9, %10
-  store i32 %"73", ptr addrspace(5) %"59", align 4
-  %11 = load i32, ptr addrspace(5) %"57", align 4
-  %"96" = call i32 @__zluda_ptx_impl_shfl_sync_idx_b32(i32 %11, i32 3, i32 4127, i32 -1)
-  store i32 %"96", ptr addrspace(5) %"58", align 4
-  %12 = load i32, ptr addrspace(5) %"59", align 4
-  %13 = load i32, ptr addrspace(5) %"58", align 4
-  %"78" = add i32 %12, %13
-  store i32 %"78", ptr addrspace(5) %"59", align 4
-  %14 = load i32, ptr addrspace(5) %"57", align 4
-  %"81" = zext i32 %14 to i64
-  store i64 %"81", ptr addrspace(5) %"56", align 8
-  %15 = load i64, ptr addrspace(5) %"56", align 8
-  %"83" = mul i64 %15, 4
-  store i64 %"83", ptr addrspace(5) %"56", align 8
+  store i32 %"37", ptr addrspace(5) %"56", align 4
+  %3 = load i32, ptr addrspace(5) %"56", align 4
+  %"89" = call i32 @__zluda_ptx_impl_shfl_sync_up_b32(i32 %3, i32 3, i32 7680, i32 -1)
+  store i32 %"89", ptr addrspace(5) %"57", align 4
+  %4 = load i32, ptr addrspace(5) %"57", align 4
+  store i32 %4, ptr addrspace(5) %"58", align 4
+  %5 = load i32, ptr addrspace(5) %"56", align 4
+  %"91" = call i32 @__zluda_ptx_impl_shfl_sync_down_b32(i32 %5, i32 3, i32 7199, i32 -1)
+  store i32 %"91", ptr addrspace(5) %"57", align 4
+  %6 = load i32, ptr addrspace(5) %"58", align 4
+  %7 = load i32, ptr addrspace(5) %"57", align 4
+  %"67" = add i32 %6, %7
+  store i32 %"67", ptr addrspace(5) %"58", align 4
+  %8 = load i32, ptr addrspace(5) %"56", align 4
+  %"93" = call i32 @__zluda_ptx_impl_shfl_sync_bfly_b32(i32 %8, i32 3, i32 6175, i32 -1)
+  store i32 %"93", ptr addrspace(5) %"57", align 4
+  %9 = load i32, ptr addrspace(5) %"58", align 4
+  %10 = load i32, ptr addrspace(5) %"57", align 4
+  %"72" = add i32 %9, %10
+  store i32 %"72", ptr addrspace(5) %"58", align 4
+  %11 = load i32, ptr addrspace(5) %"56", align 4
+  %"95" = call i32 @__zluda_ptx_impl_shfl_sync_idx_b32(i32 %11, i32 3, i32 4127, i32 -1)
+  store i32 %"95", ptr addrspace(5) %"57", align 4
+  %12 = load i32, ptr addrspace(5) %"58", align 4
+  %13 = load i32, ptr addrspace(5) %"57", align 4
+  %"77" = add i32 %12, %13
+  store i32 %"77", ptr addrspace(5) %"58", align 4
+  %14 = load i32, ptr addrspace(5) %"56", align 4
+  %15 = zext i32 %14 to i64
+  store i64 %15, ptr addrspace(5) %"55", align 8
   %16 = load i64, ptr addrspace(5) %"55", align 8
-  %17 = load i64, ptr addrspace(5) %"56", align 8
-  %"85" = add i64 %16, %17
-  store i64 %"85", ptr addrspace(5) %"55", align 8
+  %"82" = mul i64 %16, 4
+  store i64 %"82", ptr addrspace(5) %"55", align 8
+  %17 = load i64, ptr addrspace(5) %"54", align 8
   %18 = load i64, ptr addrspace(5) %"55", align 8
-  %19 = load i32, ptr addrspace(5) %"59", align 4
-  %"98" = inttoptr i64 %18 to ptr
-  store i32 %19, ptr %"98", align 4
+  %"84" = add i64 %17, %18
+  store i64 %"84", ptr addrspace(5) %"54", align 8
+  %19 = load i64, ptr addrspace(5) %"54", align 8
+  %20 = load i32, ptr addrspace(5) %"58", align 4
+  %"97" = inttoptr i64 %19 to ptr
+  store i32 %20, ptr %"97", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/shfl_sync_up_b32_pred.ll
+++ b/ptx/src/test/ll/shfl_sync_up_b32_pred.ll
@@ -2,56 +2,53 @@ declare hidden <2 x i32> @__zluda_ptx_impl_shfl_sync_up_b32_pred(i32, i32, i32, 
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @shfl_sync_up_b32_pred(ptr addrspace(4) byref(i64) %"48") #1 {
+define amdgpu_kernel void @shfl_sync_up_b32_pred(ptr addrspace(4) byref(i64) %"47") #1 {
+  %"48" = alloca i64, align 8, addrspace(5)
   %"49" = alloca i64, align 8, addrspace(5)
-  %"50" = alloca i64, align 8, addrspace(5)
+  %"50" = alloca i32, align 4, addrspace(5)
   %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i32, align 4, addrspace(5)
-  %"53" = alloca i1, align 1, addrspace(5)
+  %"52" = alloca i1, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"45"
 
 "45":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"48", align 8
-  store i64 %2, ptr addrspace(5) %"49", align 8
+  %2 = load i64, ptr addrspace(4) %"47", align 8
+  store i64 %2, ptr addrspace(5) %"48", align 8
   %"39" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"46"
+  store i32 %"39", ptr addrspace(5) %"50", align 4
+  %3 = load i32, ptr addrspace(5) %"50", align 4
+  %"73" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_up_b32_pred(i32 %3, i32 3, i32 0, i32 -1)
+  %"70" = extractelement <2 x i32> %"73", i8 0
+  %"74" = extractelement <2 x i32> %"73", i8 1
+  %4 = trunc i32 %"74" to i1
+  store i32 %"70", ptr addrspace(5) %"51", align 4
+  store i1 %4, ptr addrspace(5) %"52", align 1
+  %5 = load i1, ptr addrspace(5) %"52", align 1
+  br i1 %5, label %"17", label %"16"
 
-"46":                                             ; preds = %"45"
-  store i32 %"39", ptr addrspace(5) %"51", align 4
-  %3 = load i32, ptr addrspace(5) %"51", align 4
-  %"74" = call <2 x i32> @__zluda_ptx_impl_shfl_sync_up_b32_pred(i32 %3, i32 3, i32 0, i32 -1)
-  %"71" = extractelement <2 x i32> %"74", i8 0
-  %"75" = extractelement <2 x i32> %"74", i8 1
-  %"57" = trunc i32 %"75" to i1
-  store i32 %"71", ptr addrspace(5) %"52", align 4
-  store i1 %"57", ptr addrspace(5) %"53", align 1
-  %4 = load i1, ptr addrspace(5) %"53", align 1
-  br i1 %4, label %"17", label %"16"
-
-"16":                                             ; preds = %"46"
-  %5 = load i32, ptr addrspace(5) %"52", align 4
-  %"60" = add i32 %5, 1000
-  store i32 %"60", ptr addrspace(5) %"52", align 4
+"16":                                             ; preds = %"45"
+  %6 = load i32, ptr addrspace(5) %"51", align 4
+  %"59" = add i32 %6, 1000
+  store i32 %"59", ptr addrspace(5) %"51", align 4
   br label %"17"
 
-"17":                                             ; preds = %"16", %"46"
-  %6 = load i32, ptr addrspace(5) %"51", align 4
-  %"62" = zext i32 %6 to i64
-  store i64 %"62", ptr addrspace(5) %"50", align 8
-  %7 = load i64, ptr addrspace(5) %"50", align 8
-  %"64" = mul i64 %7, 4
-  store i64 %"64", ptr addrspace(5) %"50", align 8
-  %8 = load i64, ptr addrspace(5) %"49", align 8
-  %9 = load i64, ptr addrspace(5) %"50", align 8
-  %"66" = add i64 %8, %9
-  store i64 %"66", ptr addrspace(5) %"49", align 8
-  %10 = load i64, ptr addrspace(5) %"49", align 8
-  %11 = load i32, ptr addrspace(5) %"52", align 4
-  %"73" = inttoptr i64 %10 to ptr
-  store i32 %11, ptr %"73", align 4
+"17":                                             ; preds = %"16", %"45"
+  %7 = load i32, ptr addrspace(5) %"50", align 4
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr addrspace(5) %"49", align 8
+  %9 = load i64, ptr addrspace(5) %"49", align 8
+  %"63" = mul i64 %9, 4
+  store i64 %"63", ptr addrspace(5) %"49", align 8
+  %10 = load i64, ptr addrspace(5) %"48", align 8
+  %11 = load i64, ptr addrspace(5) %"49", align 8
+  %"65" = add i64 %10, %11
+  store i64 %"65", ptr addrspace(5) %"48", align 8
+  %12 = load i64, ptr addrspace(5) %"48", align 8
+  %13 = load i32, ptr addrspace(5) %"51", align 4
+  %"72" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"72", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/stateful_ld_st_ntid.ll
+++ b/ptx/src/test/ll/stateful_ld_st_ntid.ll
@@ -1,53 +1,50 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @stateful_ld_st_ntid(ptr addrspace(4) byref(i64) %"42", ptr addrspace(4) byref(i64) %"43") #1 {
+define amdgpu_kernel void @stateful_ld_st_ntid(ptr addrspace(4) byref(i64) %"41", ptr addrspace(4) byref(i64) %"42") #1 {
+  %"43" = alloca i64, align 8, addrspace(5)
   %"44" = alloca i64, align 8, addrspace(5)
-  %"45" = alloca i64, align 8, addrspace(5)
-  %"46" = alloca i32, align 4, addrspace(5)
+  %"45" = alloca i32, align 4, addrspace(5)
+  %"46" = alloca i64, align 8, addrspace(5)
   %"47" = alloca i64, align 8, addrspace(5)
-  %"48" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"39"
 
 "39":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"42", align 8
-  store i64 %2, ptr addrspace(5) %"44", align 8
-  %3 = load i64, ptr addrspace(4) %"43", align 8
-  store i64 %3, ptr addrspace(5) %"45", align 8
-  %4 = load i64, ptr addrspace(5) %"44", align 8
+  %2 = load i64, ptr addrspace(4) %"41", align 8
+  store i64 %2, ptr addrspace(5) %"43", align 8
+  %3 = load i64, ptr addrspace(4) %"42", align 8
+  store i64 %3, ptr addrspace(5) %"44", align 8
+  %4 = load i64, ptr addrspace(5) %"43", align 8
   %5 = inttoptr i64 %4 to ptr
-  %"51" = addrspacecast ptr %5 to ptr addrspace(1)
-  store ptr addrspace(1) %"51", ptr addrspace(5) %"44", align 8
-  %6 = load i64, ptr addrspace(5) %"45", align 8
+  %"50" = addrspacecast ptr %5 to ptr addrspace(1)
+  store ptr addrspace(1) %"50", ptr addrspace(5) %"43", align 8
+  %6 = load i64, ptr addrspace(5) %"44", align 8
   %7 = inttoptr i64 %6 to ptr
-  %"53" = addrspacecast ptr %7 to ptr addrspace(1)
-  store ptr addrspace(1) %"53", ptr addrspace(5) %"45", align 8
+  %"52" = addrspacecast ptr %7 to ptr addrspace(1)
+  store ptr addrspace(1) %"52", ptr addrspace(5) %"44", align 8
   %"38" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"40"
-
-"40":                                             ; preds = %"39"
-  store i32 %"38", ptr addrspace(5) %"46", align 4
-  %8 = load i32, ptr addrspace(5) %"46", align 4
-  %"56" = zext i32 %8 to i64
-  store i64 %"56", ptr addrspace(5) %"47", align 8
-  %9 = load i64, ptr addrspace(5) %"44", align 8
-  %10 = load i64, ptr addrspace(5) %"47", align 8
-  %"70" = add i64 %9, %10
-  store i64 %"70", ptr addrspace(5) %"44", align 8
-  %11 = load i64, ptr addrspace(5) %"45", align 8
-  %12 = load i64, ptr addrspace(5) %"47", align 8
-  %"72" = add i64 %11, %12
-  store i64 %"72", ptr addrspace(5) %"45", align 8
-  %13 = load i64, ptr addrspace(5) %"44", align 8
-  %"74" = inttoptr i64 %13 to ptr addrspace(1)
-  %14 = load i64, ptr addrspace(1) %"74", align 8
-  store i64 %14, ptr addrspace(5) %"48", align 8
-  %15 = load i64, ptr addrspace(5) %"45", align 8
-  %16 = load i64, ptr addrspace(5) %"48", align 8
-  %"75" = inttoptr i64 %15 to ptr addrspace(1)
-  store i64 %16, ptr addrspace(1) %"75", align 8
+  store i32 %"38", ptr addrspace(5) %"45", align 4
+  %8 = load i32, ptr addrspace(5) %"45", align 4
+  %9 = zext i32 %8 to i64
+  store i64 %9, ptr addrspace(5) %"46", align 8
+  %10 = load i64, ptr addrspace(5) %"43", align 8
+  %11 = load i64, ptr addrspace(5) %"46", align 8
+  %"69" = add i64 %10, %11
+  store i64 %"69", ptr addrspace(5) %"43", align 8
+  %12 = load i64, ptr addrspace(5) %"44", align 8
+  %13 = load i64, ptr addrspace(5) %"46", align 8
+  %"71" = add i64 %12, %13
+  store i64 %"71", ptr addrspace(5) %"44", align 8
+  %14 = load i64, ptr addrspace(5) %"43", align 8
+  %"73" = inttoptr i64 %14 to ptr addrspace(1)
+  %15 = load i64, ptr addrspace(1) %"73", align 8
+  store i64 %15, ptr addrspace(5) %"47", align 8
+  %16 = load i64, ptr addrspace(5) %"44", align 8
+  %17 = load i64, ptr addrspace(5) %"47", align 8
+  %"74" = inttoptr i64 %16 to ptr addrspace(1)
+  store i64 %17, ptr addrspace(1) %"74", align 8
   ret void
 }
 

--- a/ptx/src/test/ll/stateful_ld_st_ntid_chain.ll
+++ b/ptx/src/test/ll/stateful_ld_st_ntid_chain.ll
@@ -1,57 +1,54 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @stateful_ld_st_ntid_chain(ptr addrspace(4) byref(i64) %"46", ptr addrspace(4) byref(i64) %"47") #1 {
+define amdgpu_kernel void @stateful_ld_st_ntid_chain(ptr addrspace(4) byref(i64) %"45", ptr addrspace(4) byref(i64) %"46") #1 {
+  %"47" = alloca i64, align 8, addrspace(5)
   %"48" = alloca i64, align 8, addrspace(5)
   %"49" = alloca i64, align 8, addrspace(5)
   %"50" = alloca i64, align 8, addrspace(5)
   %"51" = alloca i64, align 8, addrspace(5)
   %"52" = alloca i64, align 8, addrspace(5)
-  %"53" = alloca i64, align 8, addrspace(5)
-  %"54" = alloca i32, align 4, addrspace(5)
+  %"53" = alloca i32, align 4, addrspace(5)
+  %"54" = alloca i64, align 8, addrspace(5)
   %"55" = alloca i64, align 8, addrspace(5)
-  %"56" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"43"
 
 "43":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"46", align 8
-  store i64 %2, ptr addrspace(5) %"48", align 8
-  %3 = load i64, ptr addrspace(4) %"47", align 8
-  store i64 %3, ptr addrspace(5) %"51", align 8
-  %4 = load i64, ptr addrspace(5) %"48", align 8
+  %2 = load i64, ptr addrspace(4) %"45", align 8
+  store i64 %2, ptr addrspace(5) %"47", align 8
+  %3 = load i64, ptr addrspace(4) %"46", align 8
+  store i64 %3, ptr addrspace(5) %"50", align 8
+  %4 = load i64, ptr addrspace(5) %"47", align 8
   %5 = inttoptr i64 %4 to ptr
-  %"59" = addrspacecast ptr %5 to ptr addrspace(1)
-  store ptr addrspace(1) %"59", ptr addrspace(5) %"49", align 8
-  %6 = load i64, ptr addrspace(5) %"51", align 8
+  %"58" = addrspacecast ptr %5 to ptr addrspace(1)
+  store ptr addrspace(1) %"58", ptr addrspace(5) %"48", align 8
+  %6 = load i64, ptr addrspace(5) %"50", align 8
   %7 = inttoptr i64 %6 to ptr
-  %"61" = addrspacecast ptr %7 to ptr addrspace(1)
-  store ptr addrspace(1) %"61", ptr addrspace(5) %"52", align 8
+  %"60" = addrspacecast ptr %7 to ptr addrspace(1)
+  store ptr addrspace(1) %"60", ptr addrspace(5) %"51", align 8
   %"42" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"44"
-
-"44":                                             ; preds = %"43"
-  store i32 %"42", ptr addrspace(5) %"54", align 4
-  %8 = load i32, ptr addrspace(5) %"54", align 4
-  %"64" = zext i32 %8 to i64
-  store i64 %"64", ptr addrspace(5) %"55", align 8
-  %9 = load i64, ptr addrspace(5) %"49", align 8
-  %10 = load i64, ptr addrspace(5) %"55", align 8
-  %"78" = add i64 %9, %10
-  store i64 %"78", ptr addrspace(5) %"50", align 8
-  %11 = load i64, ptr addrspace(5) %"52", align 8
-  %12 = load i64, ptr addrspace(5) %"55", align 8
-  %"80" = add i64 %11, %12
-  store i64 %"80", ptr addrspace(5) %"53", align 8
-  %13 = load i64, ptr addrspace(5) %"50", align 8
-  %"82" = inttoptr i64 %13 to ptr addrspace(1)
-  %14 = load i64, ptr addrspace(1) %"82", align 8
-  store i64 %14, ptr addrspace(5) %"56", align 8
-  %15 = load i64, ptr addrspace(5) %"53", align 8
-  %16 = load i64, ptr addrspace(5) %"56", align 8
-  %"83" = inttoptr i64 %15 to ptr addrspace(1)
-  store i64 %16, ptr addrspace(1) %"83", align 8
+  store i32 %"42", ptr addrspace(5) %"53", align 4
+  %8 = load i32, ptr addrspace(5) %"53", align 4
+  %9 = zext i32 %8 to i64
+  store i64 %9, ptr addrspace(5) %"54", align 8
+  %10 = load i64, ptr addrspace(5) %"48", align 8
+  %11 = load i64, ptr addrspace(5) %"54", align 8
+  %"77" = add i64 %10, %11
+  store i64 %"77", ptr addrspace(5) %"49", align 8
+  %12 = load i64, ptr addrspace(5) %"51", align 8
+  %13 = load i64, ptr addrspace(5) %"54", align 8
+  %"79" = add i64 %12, %13
+  store i64 %"79", ptr addrspace(5) %"52", align 8
+  %14 = load i64, ptr addrspace(5) %"49", align 8
+  %"81" = inttoptr i64 %14 to ptr addrspace(1)
+  %15 = load i64, ptr addrspace(1) %"81", align 8
+  store i64 %15, ptr addrspace(5) %"55", align 8
+  %16 = load i64, ptr addrspace(5) %"52", align 8
+  %17 = load i64, ptr addrspace(5) %"55", align 8
+  %"82" = inttoptr i64 %16 to ptr addrspace(1)
+  store i64 %17, ptr addrspace(1) %"82", align 8
   ret void
 }
 

--- a/ptx/src/test/ll/stateful_ld_st_ntid_sub.ll
+++ b/ptx/src/test/ll/stateful_ld_st_ntid_sub.ll
@@ -1,59 +1,56 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @stateful_ld_st_ntid_sub(ptr addrspace(4) byref(i64) %"50", ptr addrspace(4) byref(i64) %"51") #1 {
+define amdgpu_kernel void @stateful_ld_st_ntid_sub(ptr addrspace(4) byref(i64) %"49", ptr addrspace(4) byref(i64) %"50") #1 {
+  %"51" = alloca i64, align 8, addrspace(5)
   %"52" = alloca i64, align 8, addrspace(5)
   %"53" = alloca i64, align 8, addrspace(5)
   %"54" = alloca i64, align 8, addrspace(5)
   %"55" = alloca i64, align 8, addrspace(5)
   %"56" = alloca i64, align 8, addrspace(5)
-  %"57" = alloca i64, align 8, addrspace(5)
-  %"58" = alloca i32, align 4, addrspace(5)
+  %"57" = alloca i32, align 4, addrspace(5)
+  %"58" = alloca i64, align 8, addrspace(5)
   %"59" = alloca i64, align 8, addrspace(5)
-  %"60" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"47"
 
 "47":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"50", align 8
-  store i64 %2, ptr addrspace(5) %"52", align 8
-  %3 = load i64, ptr addrspace(4) %"51", align 8
-  store i64 %3, ptr addrspace(5) %"55", align 8
-  %4 = load i64, ptr addrspace(5) %"52", align 8
+  %2 = load i64, ptr addrspace(4) %"49", align 8
+  store i64 %2, ptr addrspace(5) %"51", align 8
+  %3 = load i64, ptr addrspace(4) %"50", align 8
+  store i64 %3, ptr addrspace(5) %"54", align 8
+  %4 = load i64, ptr addrspace(5) %"51", align 8
   %5 = inttoptr i64 %4 to ptr
-  %"63" = addrspacecast ptr %5 to ptr addrspace(1)
-  store ptr addrspace(1) %"63", ptr addrspace(5) %"53", align 8
-  %6 = load i64, ptr addrspace(5) %"55", align 8
+  %"62" = addrspacecast ptr %5 to ptr addrspace(1)
+  store ptr addrspace(1) %"62", ptr addrspace(5) %"52", align 8
+  %6 = load i64, ptr addrspace(5) %"54", align 8
   %7 = inttoptr i64 %6 to ptr
-  %"65" = addrspacecast ptr %7 to ptr addrspace(1)
-  store ptr addrspace(1) %"65", ptr addrspace(5) %"56", align 8
+  %"64" = addrspacecast ptr %7 to ptr addrspace(1)
+  store ptr addrspace(1) %"64", ptr addrspace(5) %"55", align 8
   %"42" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"48"
-
-"48":                                             ; preds = %"47"
-  store i32 %"42", ptr addrspace(5) %"58", align 4
-  %8 = load i32, ptr addrspace(5) %"58", align 4
-  %"68" = zext i32 %8 to i64
-  store i64 %"68", ptr addrspace(5) %"59", align 8
-  %9 = load i64, ptr addrspace(5) %"53", align 8
-  %10 = load i64, ptr addrspace(5) %"59", align 8
-  %"82" = sub i64 %9, %10
-  store i64 %"82", ptr addrspace(5) %"54", align 8
-  %11 = load i64, ptr addrspace(5) %"56", align 8
-  %12 = load i64, ptr addrspace(5) %"59", align 8
-  %"85" = sub i64 %11, %12
-  store i64 %"85", ptr addrspace(5) %"57", align 8
-  %13 = load i64, ptr addrspace(5) %"54", align 8
-  %"88" = inttoptr i64 %13 to ptr addrspace(1)
-  %"44" = getelementptr inbounds i8, ptr addrspace(1) %"88", i64 0
-  %14 = load i64, ptr addrspace(1) %"44", align 8
-  store i64 %14, ptr addrspace(5) %"60", align 8
-  %15 = load i64, ptr addrspace(5) %"57", align 8
-  %"89" = inttoptr i64 %15 to ptr addrspace(1)
-  %"46" = getelementptr inbounds i8, ptr addrspace(1) %"89", i64 0
-  %16 = load i64, ptr addrspace(5) %"60", align 8
-  store i64 %16, ptr addrspace(1) %"46", align 8
+  store i32 %"42", ptr addrspace(5) %"57", align 4
+  %8 = load i32, ptr addrspace(5) %"57", align 4
+  %9 = zext i32 %8 to i64
+  store i64 %9, ptr addrspace(5) %"58", align 8
+  %10 = load i64, ptr addrspace(5) %"52", align 8
+  %11 = load i64, ptr addrspace(5) %"58", align 8
+  %"81" = sub i64 %10, %11
+  store i64 %"81", ptr addrspace(5) %"53", align 8
+  %12 = load i64, ptr addrspace(5) %"55", align 8
+  %13 = load i64, ptr addrspace(5) %"58", align 8
+  %"84" = sub i64 %12, %13
+  store i64 %"84", ptr addrspace(5) %"56", align 8
+  %14 = load i64, ptr addrspace(5) %"53", align 8
+  %"87" = inttoptr i64 %14 to ptr addrspace(1)
+  %"44" = getelementptr inbounds i8, ptr addrspace(1) %"87", i64 0
+  %15 = load i64, ptr addrspace(1) %"44", align 8
+  store i64 %15, ptr addrspace(5) %"59", align 8
+  %16 = load i64, ptr addrspace(5) %"56", align 8
+  %"88" = inttoptr i64 %16 to ptr addrspace(1)
+  %"46" = getelementptr inbounds i8, ptr addrspace(1) %"88", i64 0
+  %17 = load i64, ptr addrspace(5) %"59", align 8
+  store i64 %17, ptr addrspace(1) %"46", align 8
   ret void
 }
 

--- a/ptx/src/test/ll/tid.ll
+++ b/ptx/src/test/ll/tid.ll
@@ -1,10 +1,10 @@
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @tid(ptr addrspace(4) byref(i64) %"40") #1 {
-  %"41" = alloca i64, align 8, addrspace(5)
-  %"42" = alloca i32, align 4, addrspace(5)
-  %"43" = alloca i64, align 8, addrspace(5)
-  %"44" = alloca i8, align 1, addrspace(5)
+define amdgpu_kernel void @tid(ptr addrspace(4) byref(i64) %"39") #1 {
+  %"40" = alloca i64, align 8, addrspace(5)
+  %"41" = alloca i32, align 4, addrspace(5)
+  %"42" = alloca i64, align 8, addrspace(5)
+  %"43" = alloca i8, align 1, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
@@ -12,26 +12,23 @@ define amdgpu_kernel void @tid(ptr addrspace(4) byref(i64) %"40") #1 {
 
 "37":                                             ; preds = %1
   %"36" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"38"
-
-"38":                                             ; preds = %"37"
-  store i32 %"36", ptr addrspace(5) %"42", align 4
-  %2 = load i32, ptr addrspace(5) %"42", align 4
-  %"46" = zext i32 %2 to i64
-  store i64 %"46", ptr addrspace(5) %"43", align 8
-  %3 = load i32, ptr addrspace(5) %"42", align 4
-  %"48" = trunc i32 %3 to i8
-  store i8 %"48", ptr addrspace(5) %"44", align 1
-  %4 = load i64, ptr addrspace(4) %"40", align 8
-  store i64 %4, ptr addrspace(5) %"41", align 8
-  %5 = load i64, ptr addrspace(5) %"41", align 8
-  %6 = load i64, ptr addrspace(5) %"43", align 8
-  %"51" = add i64 %5, %6
-  store i64 %"51", ptr addrspace(5) %"41", align 8
-  %7 = load i64, ptr addrspace(5) %"41", align 8
-  %8 = load i8, ptr addrspace(5) %"44", align 1
-  %"56" = inttoptr i64 %7 to ptr
-  store i8 %8, ptr %"56", align 1
+  store i32 %"36", ptr addrspace(5) %"41", align 4
+  %2 = load i32, ptr addrspace(5) %"41", align 4
+  %3 = zext i32 %2 to i64
+  store i64 %3, ptr addrspace(5) %"42", align 8
+  %4 = load i32, ptr addrspace(5) %"41", align 4
+  %5 = trunc i32 %4 to i8
+  store i8 %5, ptr addrspace(5) %"43", align 1
+  %6 = load i64, ptr addrspace(4) %"39", align 8
+  store i64 %6, ptr addrspace(5) %"40", align 8
+  %7 = load i64, ptr addrspace(5) %"40", align 8
+  %8 = load i64, ptr addrspace(5) %"42", align 8
+  %"50" = add i64 %7, %8
+  store i64 %"50", ptr addrspace(5) %"40", align 8
+  %9 = load i64, ptr addrspace(5) %"40", align 8
+  %10 = load i8, ptr addrspace(5) %"43", align 1
+  %"55" = inttoptr i64 %9 to ptr
+  store i8 %10, ptr %"55", align 1
   ret void
 }
 

--- a/ptx/src/test/ll/trap.ll
+++ b/ptx/src/test/ll/trap.ll
@@ -9,8 +9,8 @@ define amdgpu_kernel void @trap(ptr addrspace(4) byref(i64) %"34", ptr addrspace
   unreachable
 }
 
-; Function Attrs: cold noreturn nounwind
+; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
 declare void @llvm.trap() #1
 
 attributes #0 = { "amdgpu-ieee"="false" "amdgpu-unsafe-fp-atomics"="true" "denormal-fp-math"="preserve-sign" "denormal-fp-math-f32"="preserve-sign" "no-trapping-math"="true" "uniform-work-group-size"="true" }
-attributes #1 = { cold noreturn nounwind }
+attributes #1 = { cold noreturn nounwind memory(inaccessiblemem: write) }

--- a/ptx/src/test/ll/vote_all.ll
+++ b/ptx/src/test/ll/vote_all.ll
@@ -4,61 +4,55 @@ declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_laneid() #0
 
-define amdgpu_kernel void @vote_all(ptr addrspace(4) byref(i64) %"54") #1 {
-  %"55" = alloca i32, align 4, addrspace(5)
-  %"56" = alloca i32, align 4, addrspace(5)
-  %"57" = alloca i1, align 1, addrspace(5)
-  %"58" = alloca i1, align 1, addrspace(5)
-  %"59" = alloca i32, align 4, addrspace(5)
-  %"60" = alloca i64, align 8, addrspace(5)
-  %"72" = alloca i64, align 8, addrspace(5)
+define amdgpu_kernel void @vote_all(ptr addrspace(4) byref(i64) %"52") #1 {
+  %"53" = alloca i32, align 4, addrspace(5)
+  %"54" = alloca i32, align 4, addrspace(5)
+  %"55" = alloca i1, align 1, addrspace(5)
+  %"56" = alloca i1, align 1, addrspace(5)
+  %"57" = alloca i32, align 4, addrspace(5)
+  %"58" = alloca i64, align 8, addrspace(5)
+  %"70" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"49"
 
 "49":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"54", align 8
-  store i64 %2, ptr addrspace(5) %"60", align 8
+  %2 = load i64, ptr addrspace(4) %"52", align 8
+  store i64 %2, ptr addrspace(5) %"58", align 8
   %"40" = call i32 @__zluda_ptx_impl_sreg_laneid()
-  br label %"50"
-
-"50":                                             ; preds = %"49"
-  store i32 %"40", ptr addrspace(5) %"55", align 4
+  store i32 %"40", ptr addrspace(5) %"53", align 4
   %"42" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"51"
-
-"51":                                             ; preds = %"50"
-  store i32 %"42", ptr addrspace(5) %"56", align 4
-  %3 = load i32, ptr addrspace(5) %"55", align 4
+  store i32 %"42", ptr addrspace(5) %"54", align 4
+  %3 = load i32, ptr addrspace(5) %"53", align 4
   %4 = icmp ne i32 %3, 0
-  store i1 %4, ptr addrspace(5) %"57", align 1
-  store i1 false, ptr addrspace(5) %"58", align 1
-  %5 = load i1, ptr addrspace(5) %"57", align 1
+  store i1 %4, ptr addrspace(5) %"55", align 1
+  store i1 false, ptr addrspace(5) %"56", align 1
+  %5 = load i1, ptr addrspace(5) %"55", align 1
   br i1 %5, label %"18", label %"19"
 
-"18":                                             ; preds = %"51"
-  %6 = load i1, ptr addrspace(5) %"57", align 1
-  %"68" = call i1 @__zluda_ptx_impl_vote_sync_all_pred(i1 %6, i32 -2)
-  store i1 %"68", ptr addrspace(5) %"58", align 1
+"18":                                             ; preds = %"49"
+  %6 = load i1, ptr addrspace(5) %"55", align 1
+  %"66" = call i1 @__zluda_ptx_impl_vote_sync_all_pred(i1 %6, i32 -2)
+  store i1 %"66", ptr addrspace(5) %"56", align 1
   br label %"19"
 
-"19":                                             ; preds = %"18", %"51"
-  %7 = load i1, ptr addrspace(5) %"58", align 1
-  %"70" = select i1 %7, i32 1, i32 0
-  store i32 %"70", ptr addrspace(5) %"59", align 4
-  %8 = load i32, ptr addrspace(5) %"56", align 4
+"19":                                             ; preds = %"18", %"49"
+  %7 = load i1, ptr addrspace(5) %"56", align 1
+  %"68" = select i1 %7, i32 1, i32 0
+  store i32 %"68", ptr addrspace(5) %"57", align 4
+  %8 = load i32, ptr addrspace(5) %"54", align 4
   %9 = zext i32 %8 to i64
-  %"73" = mul i64 %9, 4
-  store i64 %"73", ptr addrspace(5) %"72", align 8
-  %10 = load i64, ptr addrspace(5) %"60", align 8
-  %11 = load i64, ptr addrspace(5) %"72", align 8
-  %"75" = add i64 %10, %11
-  store i64 %"75", ptr addrspace(5) %"60", align 8
-  %12 = load i64, ptr addrspace(5) %"60", align 8
-  %13 = load i32, ptr addrspace(5) %"59", align 4
-  %"80" = inttoptr i64 %12 to ptr
-  store i32 %13, ptr %"80", align 4
+  %"71" = mul i64 %9, 4
+  store i64 %"71", ptr addrspace(5) %"70", align 8
+  %10 = load i64, ptr addrspace(5) %"58", align 8
+  %11 = load i64, ptr addrspace(5) %"70", align 8
+  %"73" = add i64 %10, %11
+  store i64 %"73", ptr addrspace(5) %"58", align 8
+  %12 = load i64, ptr addrspace(5) %"58", align 8
+  %13 = load i32, ptr addrspace(5) %"57", align 4
+  %"78" = inttoptr i64 %12 to ptr
+  store i32 %13, ptr %"78", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/vote_all_sub.ll
+++ b/ptx/src/test/ll/vote_all_sub.ll
@@ -4,60 +4,54 @@ declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_laneid() #0
 
-define amdgpu_kernel void @vote_all_sub(ptr addrspace(4) byref(i64) %"56") #1 {
-  %"57" = alloca i32, align 4, addrspace(5)
-  %"58" = alloca i32, align 4, addrspace(5)
-  %"59" = alloca i1, align 1, addrspace(5)
-  %"60" = alloca i1, align 1, addrspace(5)
-  %"61" = alloca i32, align 4, addrspace(5)
-  %"62" = alloca i64, align 8, addrspace(5)
-  %"73" = alloca i64, align 8, addrspace(5)
+define amdgpu_kernel void @vote_all_sub(ptr addrspace(4) byref(i64) %"54") #1 {
+  %"55" = alloca i32, align 4, addrspace(5)
+  %"56" = alloca i32, align 4, addrspace(5)
+  %"57" = alloca i1, align 1, addrspace(5)
+  %"58" = alloca i1, align 1, addrspace(5)
+  %"59" = alloca i32, align 4, addrspace(5)
+  %"60" = alloca i64, align 8, addrspace(5)
+  %"71" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"51"
 
 "51":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"56", align 8
-  store i64 %2, ptr addrspace(5) %"62", align 8
+  %2 = load i64, ptr addrspace(4) %"54", align 8
+  store i64 %2, ptr addrspace(5) %"60", align 8
   %"41" = call i32 @__zluda_ptx_impl_sreg_laneid()
-  br label %"52"
-
-"52":                                             ; preds = %"51"
-  store i32 %"41", ptr addrspace(5) %"57", align 4
+  store i32 %"41", ptr addrspace(5) %"55", align 4
   %"43" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"53"
-
-"53":                                             ; preds = %"52"
-  store i32 %"43", ptr addrspace(5) %"58", align 4
-  %3 = load i32, ptr addrspace(5) %"57", align 4
+  store i32 %"43", ptr addrspace(5) %"56", align 4
+  %3 = load i32, ptr addrspace(5) %"55", align 4
   %4 = icmp eq i32 %3, 0
-  store i1 %4, ptr addrspace(5) %"59", align 1
-  store i1 false, ptr addrspace(5) %"60", align 1
-  %5 = load i1, ptr addrspace(5) %"59", align 1
+  store i1 %4, ptr addrspace(5) %"57", align 1
+  store i1 false, ptr addrspace(5) %"58", align 1
+  %5 = load i1, ptr addrspace(5) %"57", align 1
   br i1 %5, label %"11", label %"20"
 
-"20":                                             ; preds = %"53"
-  %"70" = call i1 @__zluda_ptx_impl_vote_sync_all_pred(i1 true, i32 -1)
-  store i1 %"70", ptr addrspace(5) %"60", align 1
+"20":                                             ; preds = %"51"
+  %"68" = call i1 @__zluda_ptx_impl_vote_sync_all_pred(i1 true, i32 -1)
+  store i1 %"68", ptr addrspace(5) %"58", align 1
   br label %"11"
 
-"11":                                             ; preds = %"20", %"53"
-  %6 = load i1, ptr addrspace(5) %"60", align 1
-  %"71" = select i1 %6, i32 1, i32 0
-  store i32 %"71", ptr addrspace(5) %"61", align 4
-  %7 = load i32, ptr addrspace(5) %"58", align 4
+"11":                                             ; preds = %"20", %"51"
+  %6 = load i1, ptr addrspace(5) %"58", align 1
+  %"69" = select i1 %6, i32 1, i32 0
+  store i32 %"69", ptr addrspace(5) %"59", align 4
+  %7 = load i32, ptr addrspace(5) %"56", align 4
   %8 = zext i32 %7 to i64
-  %"74" = mul i64 %8, 4
-  store i64 %"74", ptr addrspace(5) %"73", align 8
-  %9 = load i64, ptr addrspace(5) %"62", align 8
-  %10 = load i64, ptr addrspace(5) %"73", align 8
-  %"76" = add i64 %9, %10
-  store i64 %"76", ptr addrspace(5) %"62", align 8
-  %11 = load i64, ptr addrspace(5) %"62", align 8
-  %12 = load i32, ptr addrspace(5) %"61", align 4
-  %"81" = inttoptr i64 %11 to ptr
-  store i32 %12, ptr %"81", align 4
+  %"72" = mul i64 %8, 4
+  store i64 %"72", ptr addrspace(5) %"71", align 8
+  %9 = load i64, ptr addrspace(5) %"60", align 8
+  %10 = load i64, ptr addrspace(5) %"71", align 8
+  %"74" = add i64 %9, %10
+  store i64 %"74", ptr addrspace(5) %"60", align 8
+  %11 = load i64, ptr addrspace(5) %"60", align 8
+  %12 = load i32, ptr addrspace(5) %"59", align 4
+  %"79" = inttoptr i64 %11 to ptr
+  store i32 %12, ptr %"79", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/vote_any.ll
+++ b/ptx/src/test/ll/vote_any.ll
@@ -2,47 +2,44 @@ declare hidden i1 @__zluda_ptx_impl_vote_sync_any_pred_negate(i1, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @vote_any(ptr addrspace(4) byref(i64) %"47") #1 {
-  %"48" = alloca i32, align 4, addrspace(5)
+define amdgpu_kernel void @vote_any(ptr addrspace(4) byref(i64) %"46") #1 {
+  %"47" = alloca i32, align 4, addrspace(5)
+  %"48" = alloca i1, align 1, addrspace(5)
   %"49" = alloca i1, align 1, addrspace(5)
-  %"50" = alloca i1, align 1, addrspace(5)
-  %"51" = alloca i32, align 4, addrspace(5)
-  %"52" = alloca i64, align 8, addrspace(5)
-  %"61" = alloca i64, align 8, addrspace(5)
+  %"50" = alloca i32, align 4, addrspace(5)
+  %"51" = alloca i64, align 8, addrspace(5)
+  %"60" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"44"
 
 "44":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"47", align 8
-  store i64 %2, ptr addrspace(5) %"52", align 8
+  %2 = load i64, ptr addrspace(4) %"46", align 8
+  store i64 %2, ptr addrspace(5) %"51", align 8
   %"38" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"45"
-
-"45":                                             ; preds = %"44"
-  store i32 %"38", ptr addrspace(5) %"48", align 4
-  %3 = load i32, ptr addrspace(5) %"48", align 4
+  store i32 %"38", ptr addrspace(5) %"47", align 4
+  %3 = load i32, ptr addrspace(5) %"47", align 4
   %4 = icmp uge i32 %3, 32
-  store i1 %4, ptr addrspace(5) %"49", align 1
-  %5 = load i1, ptr addrspace(5) %"49", align 1
-  %"57" = call i1 @__zluda_ptx_impl_vote_sync_any_pred_negate(i1 %5, i32 -1)
-  store i1 %"57", ptr addrspace(5) %"50", align 1
-  %6 = load i1, ptr addrspace(5) %"50", align 1
-  %"59" = select i1 %6, i32 1, i32 0
-  store i32 %"59", ptr addrspace(5) %"51", align 4
-  %7 = load i32, ptr addrspace(5) %"48", align 4
+  store i1 %4, ptr addrspace(5) %"48", align 1
+  %5 = load i1, ptr addrspace(5) %"48", align 1
+  %"56" = call i1 @__zluda_ptx_impl_vote_sync_any_pred_negate(i1 %5, i32 -1)
+  store i1 %"56", ptr addrspace(5) %"49", align 1
+  %6 = load i1, ptr addrspace(5) %"49", align 1
+  %"58" = select i1 %6, i32 1, i32 0
+  store i32 %"58", ptr addrspace(5) %"50", align 4
+  %7 = load i32, ptr addrspace(5) %"47", align 4
   %8 = zext i32 %7 to i64
-  %"62" = mul i64 %8, 4
-  store i64 %"62", ptr addrspace(5) %"61", align 8
-  %9 = load i64, ptr addrspace(5) %"52", align 8
-  %10 = load i64, ptr addrspace(5) %"61", align 8
-  %"64" = add i64 %9, %10
-  store i64 %"64", ptr addrspace(5) %"52", align 8
-  %11 = load i64, ptr addrspace(5) %"52", align 8
-  %12 = load i32, ptr addrspace(5) %"51", align 4
-  %"69" = inttoptr i64 %11 to ptr
-  store i32 %12, ptr %"69", align 4
+  %"61" = mul i64 %8, 4
+  store i64 %"61", ptr addrspace(5) %"60", align 8
+  %9 = load i64, ptr addrspace(5) %"51", align 8
+  %10 = load i64, ptr addrspace(5) %"60", align 8
+  %"63" = add i64 %9, %10
+  store i64 %"63", ptr addrspace(5) %"51", align 8
+  %11 = load i64, ptr addrspace(5) %"51", align 8
+  %12 = load i32, ptr addrspace(5) %"50", align 4
+  %"68" = inttoptr i64 %11 to ptr
+  store i32 %12, ptr %"68", align 4
   ret void
 }
 

--- a/ptx/src/test/ll/vote_ballot.ll
+++ b/ptx/src/test/ll/vote_ballot.ll
@@ -2,43 +2,40 @@ declare hidden i32 @__zluda_ptx_impl_vote_sync_ballot_b32(i1, i32) #0
 
 declare hidden i32 @__zluda_ptx_impl_sreg_tid(i8) #0
 
-define amdgpu_kernel void @vote_ballot(ptr addrspace(4) byref(i64) %"44") #1 {
-  %"45" = alloca i32, align 4, addrspace(5)
-  %"46" = alloca i1, align 1, addrspace(5)
-  %"47" = alloca i32, align 4, addrspace(5)
-  %"48" = alloca i64, align 8, addrspace(5)
-  %"55" = alloca i64, align 8, addrspace(5)
+define amdgpu_kernel void @vote_ballot(ptr addrspace(4) byref(i64) %"43") #1 {
+  %"44" = alloca i32, align 4, addrspace(5)
+  %"45" = alloca i1, align 1, addrspace(5)
+  %"46" = alloca i32, align 4, addrspace(5)
+  %"47" = alloca i64, align 8, addrspace(5)
+  %"54" = alloca i64, align 8, addrspace(5)
   br label %1
 
 1:                                                ; preds = %0
   br label %"41"
 
 "41":                                             ; preds = %1
-  %2 = load i64, ptr addrspace(4) %"44", align 8
-  store i64 %2, ptr addrspace(5) %"48", align 8
+  %2 = load i64, ptr addrspace(4) %"43", align 8
+  store i64 %2, ptr addrspace(5) %"47", align 8
   %"37" = call i32 @__zluda_ptx_impl_sreg_tid(i8 0)
-  br label %"42"
-
-"42":                                             ; preds = %"41"
-  store i32 %"37", ptr addrspace(5) %"45", align 4
-  %3 = load i32, ptr addrspace(5) %"45", align 4
+  store i32 %"37", ptr addrspace(5) %"44", align 4
+  %3 = load i32, ptr addrspace(5) %"44", align 4
   %4 = icmp uge i32 %3, 34
-  store i1 %4, ptr addrspace(5) %"46", align 1
-  %5 = load i1, ptr addrspace(5) %"46", align 1
-  %"63" = call i32 @__zluda_ptx_impl_vote_sync_ballot_b32(i1 %5, i32 -1)
-  store i32 %"63", ptr addrspace(5) %"47", align 4
-  %6 = load i32, ptr addrspace(5) %"45", align 4
+  store i1 %4, ptr addrspace(5) %"45", align 1
+  %5 = load i1, ptr addrspace(5) %"45", align 1
+  %"62" = call i32 @__zluda_ptx_impl_vote_sync_ballot_b32(i1 %5, i32 -1)
+  store i32 %"62", ptr addrspace(5) %"46", align 4
+  %6 = load i32, ptr addrspace(5) %"44", align 4
   %7 = zext i32 %6 to i64
-  %"56" = mul i64 %7, 4
-  store i64 %"56", ptr addrspace(5) %"55", align 8
-  %8 = load i64, ptr addrspace(5) %"48", align 8
-  %9 = load i64, ptr addrspace(5) %"55", align 8
-  %"58" = add i64 %8, %9
-  store i64 %"58", ptr addrspace(5) %"48", align 8
-  %10 = load i64, ptr addrspace(5) %"48", align 8
-  %11 = load i32, ptr addrspace(5) %"47", align 4
-  %"64" = inttoptr i64 %10 to ptr
-  store i32 %11, ptr %"64", align 4
+  %"55" = mul i64 %7, 4
+  store i64 %"55", ptr addrspace(5) %"54", align 8
+  %8 = load i64, ptr addrspace(5) %"47", align 8
+  %9 = load i64, ptr addrspace(5) %"54", align 8
+  %"57" = add i64 %8, %9
+  store i64 %"57", ptr addrspace(5) %"47", align 8
+  %10 = load i64, ptr addrspace(5) %"47", align 8
+  %11 = load i32, ptr addrspace(5) %"46", align 4
+  %"63" = inttoptr i64 %10 to ptr
+  store i32 %11, ptr %"63", align 4
   ret void
 }
 


### PR DESCRIPTION
https://github.com/vosen/ZLUDA/pull/546 had LLVM IR generated before the unified LLVM codebase, so ZLUDA intrinsics are missing attrs in IR. https://github.com/vosen/ZLUDA/pull/554 also changed how IR is generated. This PR updates the LLVM IR golden files.