### PR TITLE
Implicitly convert constants from float to bit type

### DIFF
--- a/ptx/src/pass/expand_operands.rs
+++ b/ptx/src/pass/expand_operands.rs
@@ -183,6 +183,13 @@ impl<'a, 'input> FlattenArguments<'a, 'input> {
         let id = self
             .resolver
             .register_unnamed(Some((ast::Type::Scalar(scalar_t), state_space)));
+
+        let value = if scalar_t.kind() == ast::ScalarKind::Bit {
+            ast::ImmediateValue::U64(value.get_bits())
+        } else {
+            value
+        };
+
         self.result.push(Statement::Constant(ConstantDefinition {
             dst: id,
             typ: scalar_t,

--- a/ptx/src/pass/test/expand_operands/immediate_conversion.ptx
+++ b/ptx/src/pass/test/expand_operands/immediate_conversion.ptx
@@ -1,0 +1,33 @@
+.version 6.5
+.target sm_30
+.address_size 64
+
+.func () immediate_conversion ()
+{
+    .reg.b64 tmp64;
+    .reg.b32 tmp32;
+
+    mov.b64 tmp64, 1234567890U;
+    mov.b64 tmp64, -123456789;
+    mov.b32 tmp32, 0f44400000;
+    mov.b64 tmp64, 123.456789012345;
+    ret;
+}
+
+// %%% output %%%
+
+.func %1 (
+)
+{
+    .reg .b64 %2 %2;
+    .reg .b32 %3 %3;
+    .reg.b64 %4 = zluda.constant.b64 1234567890U;
+    mov.b64 %2, %4;
+    .reg.b64 %5 = zluda.constant.b64 18446744073586094827U;
+    mov.b64 %2, %5;
+    .reg.b32 %6 = zluda.constant.b32 1145044992U;
+    mov.b32 %3, %6;
+    .reg.b64 %7 = zluda.constant.b64 4638387916139875433U;
+    mov.b64 %2, %7;
+    ret;
+}

--- a/ptx/src/pass/test/expand_operands/immediates.ptx
+++ b/ptx/src/pass/test/expand_operands/immediates.ptx
@@ -1,0 +1,37 @@
+.version 6.5
+.target sm_30
+.address_size 64
+
+.func () immediates ()
+{
+    .reg.u64 tmp1;
+    .reg.s64 tmp2;
+    .reg.f32 tmp3;
+    .reg.f64 tmp4;
+
+    mov.u64 tmp1, 1234567890U;
+    mov.s64 tmp2, -123456789;
+    mov.f32 tmp3, 0f44400000;
+    mov.f64 tmp4, 123.456789012345;
+    ret;
+}
+
+// %%% output %%%
+
+.func %1 (
+)
+{
+    .reg .u64 %2 %2;
+    .reg .s64 %3 %3;
+    .reg .f32 %4 %4;
+    .reg .f64 %5 %5;
+    .reg.u64 %6 = zluda.constant.u64 1234567890U;
+    mov.u64 %2, %6;
+    .reg.s64 %7 = zluda.constant.s64 -123456789;
+    mov.s64 %3, %7;
+    .reg.f32 %8 = zluda.constant.f32 0f44400000;
+    mov.f32 %4, %8;
+    .reg.f64 %9 = zluda.constant.f64 0d405edd3c07fb4c69;
+    mov.f64 %5, %9;
+    ret;
+}

--- a/ptx/src/pass/test/expand_operands/mod.rs
+++ b/ptx/src/pass/test/expand_operands/mod.rs
@@ -18,6 +18,8 @@ fn run_expand_operands(ptx: ptx_parser::Module) -> String {
     directive2_vec_to_string(&flat_resolver, directives)
 }
 
+test_expand_operands!(immediates);
+test_expand_operands!(immediate_conversion);
 test_expand_operands!(vector_operand);
 test_expand_operands!(vector_operand_convert);
 test_expand_operands!(vector_extract);

--- a/ptx/src/pass/test/expand_operands/vector_operand.ptx
+++ b/ptx/src/pass/test/expand_operands/vector_operand.ptx
@@ -16,7 +16,7 @@
     .reg .b16 %3
 )
 {
-    .reg.b16 %4 = zluda.constant.b16 22136;
+    .reg.b16 %4 = zluda.constant.b16 22136U;
     .reg.v2.b16 %5 = zluda.repack_vector.composite.b16 %4, %3;
     mov.v2.b16 %2, %5;
     ret;

--- a/ptx/src/pass/test/expand_operands/vector_operand_convert.ptx
+++ b/ptx/src/pass/test/expand_operands/vector_operand_convert.ptx
@@ -16,7 +16,7 @@
     .reg .b16 %3
 )
 {
-    .reg.b16 %4 = zluda.constant.b16 22136;
+    .reg.b16 %4 = zluda.constant.b16 22136U;
     .reg.v2.b16 %5 = zluda.repack_vector.composite.b16 %4, %3;
     mov.b32 %2, %5;
     ret;

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -1473,10 +1473,20 @@ impl ImmediateValue {
             ImmediateValue::F32(_) | ImmediateValue::F64(_) => None,
         }
     }
+
     pub fn as_f64(&self) -> Option<f64> {
         match *self {
             ImmediateValue::F64(n) => Some(n),
             _ => None,
+        }
+    }
+
+    pub fn get_bits(&self) -> u64 {
+        match self {
+            ImmediateValue::U64(n) => *n,
+            ImmediateValue::S64(n) => *n as u64,
+            ImmediateValue::F32(n) => n.to_bits() as u64,
+            ImmediateValue::F64(n) => n.to_bits(),
         }
     }
 }
@@ -1484,10 +1494,10 @@ impl ImmediateValue {
 impl std::fmt::Display for ImmediateValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ImmediateValue::U64(n) => write!(f, "{}", n)?,
+            ImmediateValue::U64(n) => write!(f, "{}U", n)?,
             ImmediateValue::S64(n) => write!(f, "{}", n)?,
-            ImmediateValue::F32(n) => write!(f, "{}", n)?,
-            ImmediateValue::F64(n) => write!(f, "{}", n)?,
+            ImmediateValue::F32(n) => write!(f, "0f{:x}", n.to_bits())?,
+            ImmediateValue::F64(n) => write!(f, "0d{:x}", n.to_bits())?,
         }
         Ok(())
     }


### PR DESCRIPTION
There is apparently production code like this:

```
        mov.b32         %r88, 0f44400000;
```