### PR TITLE
Fix typo: vec_acccess -> vector_read in emit_vector_read

### DIFF
--- a/ptx/src/pass/llvm/emit.rs
+++ b/ptx/src/pass/llvm/emit.rs
@@ -1497,17 +1497,17 @@ impl<'a> MethodEmitContext<'a> {
         Ok(())
     }
 
-    fn emit_vector_read(&mut self, vec_acccess: VectorRead) -> Result<(), TranslateError> {
-        let src = self.resolver.value(vec_acccess.vector_src)?;
+    fn emit_vector_read(&mut self, vector_read: VectorRead) -> Result<(), TranslateError> {
+        let src = self.resolver.value(vector_read.vector_src)?;
         let index = unsafe {
             LLVMConstInt(
                 get_scalar_type(self.context, ast::ScalarType::B8),
-                vec_acccess.member as _,
+                vector_read.member as _,
                 0,
             )
         };
         self.resolver
-            .with_result(vec_acccess.scalar_dst, |dst| unsafe {
+            .with_result(vector_read.scalar_dst, |dst| unsafe {
                 LLVMBuildExtractElement(self.builder, src, index, dst)
             });
         Ok(())


### PR DESCRIPTION
Renames the local parameter `vec_acccess` (3 c's) to `vector_read` in `emit_vector_read`. The new name also matches the function name and the convention used by the sibling functions `emit_vector_write` (param `vector_write`) and `emit_vector_repack` (param `repack`).

Pure rename of a function-local identifier, no behavior change.