### PR TITLE
Fix typo: compatiblity -> compatibility in xtask comment

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -383,7 +383,7 @@ mod os {
 
     // Unfortunately when linking against amdhip64.so, it encodes SONAME with versioned
     // filename, e.g. libamdhip64.so.7. We instead want to link against unversioned
-    // libamdhip64.so to allow compatiblity with both ROCm 6 and ROCm 7
+    // libamdhip64.so to allow compatibility with both ROCm 6 and ROCm 7
     // We use `patchelf`. I've tried arwen library: https://nichmor.github.io/arwen/,
     // it supports replacing DT_NEEDED entries, but it seems to produce broken binaries
     pub fn strip_rocm_versions_from_dt_needed(target_dir: &PathBuf, profile: &str) {


### PR DESCRIPTION
Single-character typo fix in a comment in `xtask/src/main.rs` (`compatiblity` -> `compatibility`). Comment-only, no behavior change.