### PR TITLE
Fix typo: overriden -> overridden in zluda_redirect

### DIFF
--- a/zluda_redirect/src/lib.rs
+++ b/zluda_redirect/src/lib.rs
@@ -754,20 +754,20 @@ struct DetourDetachGuard {
     state: DetourUndoState,
     suspended_threads: Vec<HANDLE>,
     // First element is the original fn, second is the new fn
-    overriden_non_cuda_fns: Vec<(*mut *mut c_void, *mut c_void)>,
+    overridden_non_cuda_fns: Vec<(*mut *mut c_void, *mut c_void)>,
 }
 
 impl DetourDetachGuard {
     // First element in the pair is ptr to original fn, second argument is the
     // new function. We accept *mut *mut c_void instead of *mut c_void as the
     // first element in the pair, because somehow otherwise original functions
-    // also get overriden, so for example ZludaLoadLibraryExW ends calling
+    // also get overridden, so for example ZludaLoadLibraryExW ends calling
     // itself recursively until stack overflow exception occurs
     unsafe fn new<'a>() -> Option<Self> {
         let mut result = DetourDetachGuard {
             state: DetourUndoState::DoNothing,
             suspended_threads: Vec::new(),
-            overriden_non_cuda_fns: Vec::new(),
+            overridden_non_cuda_fns: Vec::new(),
         };
         if DetourTransactionBegin() != NO_ERROR as i32 {
             return None;
@@ -781,7 +781,7 @@ impl DetourDetachGuard {
                 return None;
             }
         }
-        result.overriden_non_cuda_fns.extend_from_slice(&[
+        result.overridden_non_cuda_fns.extend_from_slice(&[
             (
                 &raw mut LOAD_LIBRARY_A as *mut _ as *mut *mut c_void,
                 ZludaLoadLibraryA as *mut c_void,
@@ -824,7 +824,7 @@ impl DetourDetachGuard {
             ),
             (&raw mut LDR_LOAD_DLL as *mut _ as _, ZludaLdrLoadDll as _),
         ]);
-        for (original_fn, new_fn) in result.overriden_non_cuda_fns.iter().copied() {
+        for (original_fn, new_fn) in result.overridden_non_cuda_fns.iter().copied() {
             if DetourAttach(original_fn, new_fn) != NO_ERROR as i32 {
                 return None;
             }
@@ -911,7 +911,7 @@ impl Drop for DetourDetachGuard {
             DetourUndoState::DetachDetours => unsafe {
                 DetourTransactionBegin();
                 DetourUpdateThread(GetCurrentThread().0);
-                for (original_fn, new_fn) in self.overriden_non_cuda_fns.iter().copied() {
+                for (original_fn, new_fn) in self.overridden_non_cuda_fns.iter().copied() {
                     DetourDetach(original_fn, new_fn);
                 }
                 if let Ok(mut nvrtc_detours) = nvrtc_detours().lock() {


### PR DESCRIPTION
Renames the misspelled private field `overriden_non_cuda_fns` to `overridden_non_cuda_fns` in `zluda_redirect` (`DetourDetachGuard`), and fixes the same misspelling in a nearby comment. All 6 occurrences are in a single file; the field is private so there is no external impact. No behavior change.