### PR TITLE
ptx: parse `exit` instruction

### DIFF
--- a/ptx/src/pass/insert_post_saturation.rs
+++ b/ptx/src/pass/insert_post_saturation.rs
@@ -202,6 +202,7 @@ fn run_instruction<'input>(
         }
         | ast::Instruction::Tanh { .. }
         | ast::Instruction::Trap {}
+        | ast::Instruction::Exit {}
         | ast::Instruction::Xor { .. }
         | ast::Instruction::Vote { .. }
         | ast::Instruction::ReduxSync { .. }

--- a/ptx/src/pass/instruction_mode_to_global_mode/mod.rs
+++ b/ptx/src/pass/instruction_mode_to_global_mode/mod.rs
@@ -2128,6 +2128,7 @@ fn get_modes<T: ast::Operand>(inst: &ast::Instruction<T>) -> InstructionModes {
         | ast::Instruction::Activemask { .. }
         | ast::Instruction::Membar { .. }
         | ast::Instruction::Trap {}
+        | ast::Instruction::Exit {}
         | ast::Instruction::Not { .. }
         | ast::Instruction::Or { .. }
         | ast::Instruction::And { .. }

--- a/ptx/src/pass/llvm/emit.rs
+++ b/ptx/src/pass/llvm/emit.rs
@@ -193,6 +193,10 @@ impl<'a, 'input> ModuleEmitContext<'a, 'input> {
             Self::func_call_convention()
         };
         unsafe { LLVMSetFunctionCallConv(fn_, call_conv) };
+        // Capture before the loop below: `for directive in method.tuning` calls
+        // into_iter(), which moves method.tuning and partially moves `method`,
+        // after which method.is_kernel() (a &self borrow) would be rejected.
+        let is_kernel = method.is_kernel();
         for directive in method.tuning {
             match directive {
                 ptx_parser::TuningDirective::NoReturn => {
@@ -213,7 +217,7 @@ impl<'a, 'input> ModuleEmitContext<'a, 'input> {
             unsafe { LLVMPositionBuilderAtEnd(self.builder.get(), real_bb) };
             let base_32bit_memory = method.kernel_meta32.as_ref().map(|m| m.implicit_memory_ptr);
             let mut method_emitter =
-                MethodEmitContext::new(self, fn_, variables_builder, base_32bit_memory);
+                MethodEmitContext::new(self, fn_, is_kernel, variables_builder, base_32bit_memory);
             for var in method.return_arguments {
                 method_emitter.emit_variable(var)?;
             }
@@ -461,6 +465,10 @@ struct MethodEmitContext<'a> {
     context: LLVMContextRef,
     module: LLVMModuleRef,
     method: LLVMValueRef,
+    // Whether `method` is a top-level entry routine (.entry) rather than a callable
+    // .func. Only entry routines may terminate the thread by returning, which is what
+    // `exit` lowers to; see emit_exit.
+    is_kernel: bool,
     builder: LLVMBuilderRef,
     variables_builder: Builder,
     resolver: &'a mut ResolveIdent,
@@ -472,6 +480,7 @@ impl<'a> MethodEmitContext<'a> {
     fn new(
         parent: &'a mut ModuleEmitContext,
         method: LLVMValueRef,
+        is_kernel: bool,
         variables_builder: Builder,
         base_32bit_memory: Option<SpirvWord>,
     ) -> MethodEmitContext<'a> {
@@ -482,6 +491,7 @@ impl<'a> MethodEmitContext<'a> {
             variables_builder,
             resolver: &mut parent.resolver,
             method,
+            is_kernel,
             carry_flag: None,
             base_32bit_memory: base_32bit_memory,
         }
@@ -641,6 +651,7 @@ impl<'a> MethodEmitContext<'a> {
             ast::Instruction::BarWarp { .. } => self.emit_bar_warp(),
             ast::Instruction::Membar { data } => self.emit_membar(data),
             ast::Instruction::Trap {} => self.emit_trap(),
+            ast::Instruction::Exit {} => self.emit_exit(),
             ast::Instruction::Tanh { data, arguments } => self.emit_tanh(data, arguments),
             ast::Instruction::CpAsync { data, arguments } => self.emit_cp_async(data, arguments),
             ast::Instruction::Copysign { data, arguments } => self.emit_copysign(data, arguments),
@@ -1169,6 +1180,23 @@ impl<'a> MethodEmitContext<'a> {
 
     fn emit_ret(&self, _data: ast::RetData) {
         unsafe { LLVMBuildRetVoid(self.builder) };
+    }
+
+    fn emit_exit(&self) -> Result<(), TranslateError> {
+        // `exit` terminates the calling thread regardless of how deep it is in the call
+        // stack. In a top-level entry routine returning has the same effect (PTX ISA: "A
+        // return instruction executed in a top-level entry routine will terminate thread
+        // execution"), so reuse the Ret path. ZLUDA does not inline .func device
+        // functions, so inside one a `ret` would only unwind to the caller and leave the
+        // thread running -- we can't model per-lane thread termination from a nested
+        // function, so refuse it loudly instead of mis-executing.
+        if !self.is_kernel {
+            return Err(error_todo_msg(
+                "`exit` is only supported in entry (.entry) functions, not callable (.func) functions",
+            ));
+        }
+        self.emit_ret(ast::RetData { uniform: false });
+        Ok(())
     }
 
     fn emit_call(

--- a/ptx/src/pass/normalize_basic_blocks.rs
+++ b/ptx/src/pass/normalize_basic_blocks.rs
@@ -129,6 +129,7 @@ fn is_block_terminator(
     match statement {
         Statement::Conditional(..)
         | Statement::Instruction(ast::Instruction::Trap { .. })
+        | Statement::Instruction(ast::Instruction::Exit { .. })
         | Statement::Instruction(ast::Instruction::Bra { .. })
         // Normally call is not a terminator, but we treat it as such because it
         // makes the "instruction modes to global modes" pass possible

--- a/ptx/src/test/spirv_run/exit_.ptx
+++ b/ptx/src/test/spirv_run/exit_.ptx
@@ -1,0 +1,26 @@
+.version 6.5
+.target sm_30
+.address_size 64
+
+.visible .entry exit_(
+    .param .u64 input,
+    .param .u64 output
+)
+{
+    .reg .u64   in_addr;
+    .reg .u64   out_addr;
+    .reg .u32   temp;
+    .reg .u32   temp2;
+    .reg .pred  p;
+
+    ld.param.u64    in_addr, [input];
+    ld.param.u64    out_addr, [output];
+
+    ld.u32          temp, [in_addr];
+    st.u32          [out_addr], temp;
+    setp.eq.u32     p, temp, temp;      // always true
+    @p exit;                            // terminate the thread here...
+    mov.u32         temp2, 999;
+    st.u32          [out_addr], temp2;  // ...so this overwrite must NOT happen
+    ret;
+}

--- a/ptx/src/test/spirv_run/mod.rs
+++ b/ptx/src/test/spirv_run/mod.rs
@@ -435,6 +435,7 @@ test_ptx!(
     [1.0000001, 1.0f32]
 );
 test_ptx!(multiple_return, [5u32], [6u32, 123u32]);
+test_ptx!(exit_, [5u32], [5u32]);
 test_ptx!(warp_sz, [0u8], [32u8]);
 test_ptx!(tanh, [f32::INFINITY], [1.0f32]);
 test_ptx!(cp_async, [0u32], [1u32, 2u32, 3u32, 0u32]);

--- a/ptx_parser/src/ast.rs
+++ b/ptx_parser/src/ast.rs
@@ -760,6 +760,9 @@ ptx_parser_macros::generate_instruction_type!(
             }
         },
         Trap { },
+        Exit {
+            display: write!(f, "exit")?
+        },
         Xor {
             type: Type::Scalar(data.clone()),
             data: ScalarType,

--- a/ptx_parser/src/lib.rs
+++ b/ptx_parser/src/lib.rs
@@ -3953,6 +3953,22 @@ derive_parser!(
         Instruction::Ret { data: RetData { uniform: uni } }
     }
 
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#control-flow-instructions-exit
+    // `exit` terminates the calling thread regardless of call depth. In a top-level
+    // entry routine -- the common case, e.g. CUB's onesweep radix-sort kernel early-outs
+    // an out-of-range tile with it -- a void return has the same effect (PTX ISA: "A
+    // return instruction executed in a top-level entry routine will terminate thread
+    // execution"), so emit lowers Exit to Ret there. Inside a `.func` device function a
+    // `ret` would only unwind to the caller and let the thread keep running, which is the
+    // wrong semantics; ZLUDA does not inline `.func`s, so emit refuses Exit in that case
+    // rather than silently mis-executing. Kept as its own opcode (not folded into Ret
+    // here) precisely so emit can tell the entry and non-entry cases apart -- without any
+    // rule the parser would instead drop the whole enclosing directive via error recovery
+    // and release builds (parse_module_unchecked) would load the module without it.
+    exit => {
+        Instruction::Exit { }
+    }
+
     mul24.mode.type  d, a, b => {
         ast::Instruction::Mul24 {
             data: ast::Mul24Details {
@@ -4574,6 +4590,27 @@ mod tests {
             errors[1],
             PtxError::UnrecognizedStatement("unknown_op2 temp2, temp;")
         ));
+    }
+
+    #[test]
+    fn exit_parses_as_terminator() {
+        // `exit` must parse; otherwise error recovery drops the whole enclosing
+        // directive (and release builds then load the module without it). Regression
+        // test for CUB onesweep radix-sort kernels, which early-out a tile with `exit`.
+        let text = "
+            .version 6.5
+            .target sm_60
+            .address_size 64
+
+            .visible .entry uses_exit(
+            )
+            {
+                exit;
+                ret;
+            }";
+        let module = parse_module_checked(text).unwrap();
+        assert_eq!(module.invalid_directives, 0);
+        assert_eq!(module.directives.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
The parser had no rule for `exit`, so any kernel using it failed with `UnrecognizedStatement("exit;")`. Because directives are parsed with error recovery, that drops the *entire enclosing kernel*; in release builds the module loader uses `parse_module_unchecked`, which accepts a module with `invalid_directives > 0`, so the kernel is silently absent and a later `cuModuleGetFunction` / `cuLibraryGetKernel` returns NOT_FOUND.

This bites real code: CUB's `DeviceRadixSort` onesweep kernel early-outs an out-of-range tile with `exit`, so `DeviceRadixSort` silently misbehaves under ZLUDA (the sort never runs and callers that don't check the return code get unsorted data).

`exit` terminates the calling thread regardless of call depth. That matches a void return only in a top-level entry routine (PTX ISA: "A return instruction executed in a top-level entry routine will terminate thread execution"); inside a callable `.func` a `ret` would unwind to the caller and let the thread keep running. ZLUDA does not inline `.func`s, so parse `exit` to its own `Instruction::Exit` terminator (handled like `Trap` through the passes) and at emit lower it to `Ret` when the enclosing method is an entry routine, otherwise raise a translate error rather than silently mis-executing.

Adds a parser unit test and a spirv_run test that early-outs with `exit` in an entry kernel and checks the post-exit store does not execute.