### PR TITLE
docs: clarify unofficial HIP SDK column refers to AMD nightlies

### DIFF
--- a/docs/src/hip_sdk.md
+++ b/docs/src/hip_sdk.md
@@ -5,7 +5,7 @@ On Windows, in addition to installing the GPU driver, you need to install the HI
 <table width="100%">
 <tr >
 <th> Official HIP SDK </th>
-<th> Unofficial HIP SDK builds </th>
+<th> Nightly HIP SDK builds </th>
 </tr>
 <tr/>
 <tr>
@@ -26,7 +26,7 @@ On Windows, in addition to installing the GPU driver, you need to install the HI
 <td style="width: 50%;border:none;vertical-align: top">
 
 ❌ Manual installation\
-❌ Unstable and unsupported by AMD\
+❌ Nightly builds by AMD - no stability guarantees\
 ✅ Newer code\
 ✅ Machine Learning support (required for PyTorch, TensorFlow, etc.)
 


### PR DESCRIPTION
The tarballs in the right-hand column are produced by [TheRock](https://github.com/ROCm/TheRock), AMD's own open-source build system, so both "unofficial" and "unsupported by AMD" wrongly implied AMD isn't involved.

This reframes the contrast as stable release vs nightly  while keeping the honest warning that nightlies carry no stability guarantees.