### PR TITLE
Split PTX LLVM emission into common and per-kernel modules

### DIFF
--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -118,3 +118,58 @@ pub(super) fn kernel_declaration_sets(
         })
         .collect()
 }
+
+pub(super) struct KernelModulePlan {
+    pub(super) kernel: Function<ast::Instruction<SpirvWord>, SpirvWord>,
+    pub(super) declarations: Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>,
+}
+
+pub(super) struct KernelCompilationPlan {
+    pub(super) common: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
+    pub(super) kernels: Vec<KernelModulePlan>,
+}
+
+pub(super) fn build_compilation_plan(
+    directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
+) -> KernelCompilationPlan {
+    let mut declaration_sets = kernel_declaration_sets(&directives);
+    let mut common = Vec::new();
+    let mut kernels = Vec::new();
+
+    for directive in directives {
+        match directive {
+            Directive2::Variable(..) => common.push(directive),
+            Directive2::Method(function) if function.is_kernel() => {
+                let declarations = declaration_sets.remove(&function.name).unwrap_or_default();
+
+                kernels.push(KernelModulePlan {
+                    kernel: function,
+                    declarations,
+                });
+            }
+            Directive2::Method(..) => common.push(directive),
+        }
+    }
+
+    KernelCompilationPlan { common, kernels }
+}
+
+impl KernelCompilationPlan {
+    pub(super) fn into_monolithic_directives(
+        self,
+    ) -> Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>> {
+        let mut directives = self.common;
+
+        directives.extend(self.kernels.into_iter().map(|kernel_plan| {
+            let KernelModulePlan {
+                kernel,
+                declarations,
+            } = kernel_plan;
+
+            drop(declarations);
+            Directive2::Method(kernel)
+        }));
+
+        directives
+    }
+}

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -126,7 +126,7 @@ pub(super) fn global_declaration(
     let mut declaration = variable.clone();
     declaration.info.array_init.clear();
 
-    (linking, declaration)
+    (linking | ast::LinkingDirective::EXTERN, declaration)
 }
 
 pub(super) struct KernelModulePlan {

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -174,6 +174,7 @@ pub(super) fn build_compilation_plan(
 }
 
 impl KernelCompilationPlan {
+    #[cfg(test)]
     pub(super) fn into_monolithic_directives(
         self,
     ) -> Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>> {

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -119,8 +119,19 @@ pub(super) fn kernel_declaration_sets(
         .collect()
 }
 
+pub(super) fn global_declaration(
+    linking: ast::LinkingDirective,
+    variable: &ast::Variable<SpirvWord>,
+) -> (ast::LinkingDirective, ast::Variable<SpirvWord>) {
+    let mut declaration = variable.clone();
+    declaration.info.array_init.clear();
+
+    (linking, declaration)
+}
+
 pub(super) struct KernelModulePlan {
     pub(super) kernel: Function<ast::Instruction<SpirvWord>, SpirvWord>,
+    pub(super) global_declarations: Vec<(ast::LinkingDirective, ast::Variable<SpirvWord>)>,
     pub(super) declarations: Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>,
 }
 
@@ -133,6 +144,13 @@ pub(super) fn build_compilation_plan(
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> KernelCompilationPlan {
     let mut declaration_sets = kernel_declaration_sets(&directives);
+    let global_declarations = directives
+        .iter()
+        .filter_map(|directive| match directive {
+            Directive2::Variable(linking, variable) => Some(global_declaration(*linking, variable)),
+            Directive2::Method(..) => None,
+        })
+        .collect::<Vec<_>>();
     let mut common = Vec::new();
     let mut kernels = Vec::new();
 
@@ -144,6 +162,7 @@ pub(super) fn build_compilation_plan(
 
                 kernels.push(KernelModulePlan {
                     kernel: function,
+                    global_declarations: global_declarations.clone(),
                     declarations,
                 });
             }
@@ -163,9 +182,11 @@ impl KernelCompilationPlan {
         directives.extend(self.kernels.into_iter().map(|kernel_plan| {
             let KernelModulePlan {
                 kernel,
+                global_declarations,
                 declarations,
             } = kernel_plan;
 
+            drop(global_declarations);
             drop(declarations);
             Directive2::Method(kernel)
         }));

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -1,0 +1,82 @@
+use super::{Directive2, Function, SpirvWord, Statement};
+use ptx_parser as ast;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+pub(super) fn direct_callees(
+    function: &Function<ast::Instruction<SpirvWord>, SpirvWord>,
+) -> FxHashSet<SpirvWord> {
+    let Some(body) = &function.body else {
+        return FxHashSet::default();
+    };
+
+    body.iter()
+        .filter_map(|statement| match statement {
+            Statement::Instruction(ast::Instruction::Call { arguments, .. }) => {
+                Some(arguments.func)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+pub(super) fn reachable_callees(
+    root: SpirvWord,
+    functions: &FxHashMap<SpirvWord, &Function<ast::Instruction<SpirvWord>, SpirvWord>>,
+) -> FxHashSet<SpirvWord> {
+    let mut reachable = FxHashSet::default();
+    let mut visited = FxHashSet::default();
+    let mut pending = vec![root];
+
+    visited.insert(root);
+
+    while let Some(function_name) = pending.pop() {
+        let Some(function) = functions.get(&function_name) else {
+            continue;
+        };
+
+        for callee in direct_callees(function) {
+            if visited.insert(callee) {
+                reachable.insert(callee);
+                pending.push(callee);
+            }
+        }
+    }
+
+    reachable
+}
+
+pub(super) fn function_index<'a>(
+    directives: &'a [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+) -> FxHashMap<SpirvWord, &'a Function<ast::Instruction<SpirvWord>, SpirvWord>> {
+    directives
+        .iter()
+        .filter_map(|directive| match directive {
+            Directive2::Method(function) => Some((function.name, function)),
+            Directive2::Variable(..) => None,
+        })
+        .collect()
+}
+
+pub(super) fn kernel_dependencies(
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
+    let functions = function_index(directives);
+
+    functions
+        .values()
+        .filter(|function| function.is_kernel())
+        .map(|function| (function.name, reachable_callees(function.name, &functions)))
+        .collect()
+}
+
+pub(super) fn kernel_method_sets(
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
+    kernel_dependencies(directives)
+        .into_iter()
+        .map(|(kernel, mut dependencies)| {
+            dependencies.insert(kernel);
+            (kernel, dependencies)
+        })
+        .collect()
+}

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -80,3 +80,41 @@ pub(super) fn kernel_method_sets(
         })
         .collect()
 }
+
+pub(super) fn method_declaration(
+    function: &Function<ast::Instruction<SpirvWord>, SpirvWord>,
+) -> Function<ast::Instruction<SpirvWord>, SpirvWord> {
+    debug_assert!(!function.is_kernel());
+
+    Function {
+        return_arguments: function.return_arguments.clone(),
+        name: function.name,
+        input_arguments: function.input_arguments.clone(),
+        body: None,
+        kernel_attributes: None,
+        import_as: function.import_as.clone(),
+        tuning: function.tuning.clone(),
+        linkage: function.linkage,
+        kernel_meta32: None,
+    }
+}
+
+pub(super) fn kernel_declaration_sets(
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+) -> FxHashMap<SpirvWord, Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
+    let functions = function_index(directives);
+
+    kernel_method_sets(directives)
+        .into_iter()
+        .map(|(kernel, methods)| {
+            let declarations = methods
+                .into_iter()
+                .filter(|method| *method != kernel)
+                .filter_map(|method| functions.get(&method))
+                .map(|function| method_declaration(function))
+                .collect();
+
+            (kernel, declarations)
+        })
+        .collect()
+}

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -202,6 +202,7 @@ pub(super) fn kernel_dependencies(
         .collect()
 }
 
+#[cfg(test)]
 pub(super) fn kernel_method_sets(
     directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
@@ -232,19 +233,20 @@ pub(super) fn method_declaration(
     }
 }
 
-pub(super) fn kernel_declaration_sets(
-    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+fn kernel_declaration_sets_from_dependencies(
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    dependencies: &FxHashMap<SpirvWord, FxHashSet<SpirvWord>>,
 ) -> FxHashMap<SpirvWord, Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
-    let method_sets = kernel_method_sets(directives);
     let functions = function_index(directives);
 
-    method_sets
-        .into_iter()
-        .map(|(kernel, methods)| {
-            let declarations = methods
-                .into_iter()
-                .filter(|method| *method != kernel)
-                .filter_map(|method| functions.get(&method))
+    dependencies
+        .iter()
+        .map(|(&kernel, symbols)| {
+            let declarations = symbols
+                .iter()
+                .copied()
+                .filter(|symbol| *symbol != kernel)
+                .filter_map(|symbol| functions.get(&symbol))
                 .filter_map(|functions| {
                     functions
                         .iter()
@@ -258,6 +260,14 @@ pub(super) fn kernel_declaration_sets(
             (kernel, declarations)
         })
         .collect()
+}
+
+#[cfg(test)]
+pub(super) fn kernel_declaration_sets(
+    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+) -> FxHashMap<SpirvWord, Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
+    let dependencies = kernel_dependencies(directives);
+    kernel_declaration_sets_from_dependencies(directives, &dependencies)
 }
 
 pub(super) fn global_declaration(
@@ -286,7 +296,8 @@ pub(super) fn build_compilation_plan(
 ) -> KernelCompilationPlan {
     let mut directives = directives;
     let reachable_symbols = kernel_dependencies(&mut directives);
-    let mut declaration_sets = kernel_declaration_sets(&mut directives);
+    let mut declaration_sets =
+        kernel_declaration_sets_from_dependencies(&directives, &reachable_symbols);
     let globals = directives
         .iter()
         .filter_map(|directive| match directive {

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -232,11 +232,19 @@ fn kernel_declaration_sets_from_dependencies(
     dependencies
         .iter()
         .map(|(&kernel, symbols)| {
-            let declarations = symbols
+            let mut emitted = FxHashSet::default();
+            let declarations = directives
                 .iter()
-                .copied()
-                .filter(|symbol| *symbol != kernel)
-                .filter_map(|symbol| functions.get(&symbol))
+                .filter_map(|directive| match directive {
+                    Directive2::Method(function)
+                        if function.name != kernel
+                            && symbols.contains(&function.name)
+                            && emitted.insert(function.name) =>
+                    {
+                        functions.get(&function.name)
+                    }
+                    _ => None,
+                })
                 .filter_map(|functions| {
                     functions
                         .iter()
@@ -284,7 +292,6 @@ pub(super) struct KernelCompilationPlan {
 pub(super) fn build_compilation_plan(
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> KernelCompilationPlan {
-    let directives = directives;
     let reachable_symbols = kernel_dependencies(&directives);
     let mut declaration_sets =
         kernel_declaration_sets_from_dependencies(&directives, &reachable_symbols);

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -1,48 +1,101 @@
 use super::{Directive2, Function, SpirvWord, Statement};
+use petgraph::{graph::NodeIndex, visit::Dfs, Graph};
 use ptx_parser as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
 
-pub(super) fn direct_callees(
-    function: &Function<ast::Instruction<SpirvWord>, SpirvWord>,
-) -> FxHashSet<SpirvWord> {
-    let Some(body) = &function.body else {
-        return FxHashSet::default();
-    };
-
-    body.iter()
-        .filter_map(|statement| match statement {
-            Statement::Instruction(ast::Instruction::Call { arguments, .. }) => {
-                Some(arguments.func)
-            }
-            _ => None,
-        })
-        .collect()
+pub(super) struct DependencyGraph {
+    graph: Graph<SpirvWord, ()>,
+    nodes: FxHashMap<SpirvWord, NodeIndex>,
 }
 
-pub(super) fn reachable_callees(
-    root: SpirvWord,
-    functions: &FxHashMap<SpirvWord, &Function<ast::Instruction<SpirvWord>, SpirvWord>>,
-) -> FxHashSet<SpirvWord> {
-    let mut reachable = FxHashSet::default();
-    let mut visited = FxHashSet::default();
-    let mut pending = vec![root];
-
-    visited.insert(root);
-
-    while let Some(function_name) = pending.pop() {
-        let Some(function) = functions.get(&function_name) else {
-            continue;
+impl DependencyGraph {
+    pub(super) fn from_directives(
+        directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    ) -> Self {
+        let mut result = Self {
+            graph: Graph::new(),
+            nodes: FxHashMap::default(),
         };
 
-        for callee in direct_callees(function) {
-            if visited.insert(callee) {
-                reachable.insert(callee);
-                pending.push(callee);
+        // Register all module-level symbols before adding edges. A function
+        // declaration and its definition share the same SpirvWord node.
+        for directive in directives {
+            match directive {
+                Directive2::Variable(_, variable) => {
+                    result.add_node(variable.name);
+                }
+                Directive2::Method(function) => {
+                    result.add_node(function.name);
+                }
             }
+        }
+
+        for directive in directives {
+            match directive {
+                Directive2::Variable(_, variable) => {
+                    for initializer in &variable.info.array_init {
+                        if let ast::RegOrImmediate::Reg(dependency) = initializer {
+                            result.add_dependency(variable.name, *dependency);
+                        }
+                    }
+                }
+                Directive2::Method(function) => {
+                    let Some(body) = &function.body else {
+                        continue;
+                    };
+
+                    for statement in body {
+                        if let Statement::Instruction(ast::Instruction::Call {
+                            arguments, ..
+                        }) = statement
+                        {
+                            result.add_dependency(function.name, arguments.func);
+                        }
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    fn add_node(&mut self, symbol: SpirvWord) -> NodeIndex {
+        if let Some(index) = self.nodes.get(&symbol) {
+            return *index;
+        }
+
+        let index = self.graph.add_node(symbol);
+        self.nodes.insert(symbol, index);
+        index
+    }
+
+    fn add_dependency(&mut self, from: SpirvWord, to: SpirvWord) {
+        let from = self.add_node(from);
+        let to = self.add_node(to);
+
+        if self.graph.find_edge(from, to).is_none() {
+            self.graph.add_edge(from, to, ());
         }
     }
 
-    reachable
+    pub(super) fn reachable_from(&self, root: SpirvWord) -> FxHashSet<SpirvWord> {
+        let Some(root_index) = self.nodes.get(&root).copied() else {
+            return FxHashSet::default();
+        };
+
+        let mut reachable = FxHashSet::default();
+        let mut traversal = Dfs::new(&self.graph, root_index);
+
+        while let Some(index) = traversal.next(&self.graph) {
+            let symbol = self.graph[index];
+
+            if symbol != root {
+                reachable.insert(symbol);
+            }
+        }
+
+        reachable
+    }
 }
 
 pub(super) fn function_index<'a>(
@@ -60,12 +113,16 @@ pub(super) fn function_index<'a>(
 pub(super) fn kernel_dependencies(
     directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
-    let functions = function_index(directives);
+    let graph = DependencyGraph::from_directives(directives);
 
-    functions
-        .values()
-        .filter(|function| function.is_kernel())
-        .map(|function| (function.name, reachable_callees(function.name, &functions)))
+    directives
+        .iter()
+        .filter_map(|directive| match directive {
+            Directive2::Method(function) if function.is_kernel() => {
+                Some((function.name, graph.reachable_from(function.name)))
+            }
+            _ => None,
+        })
         .collect()
 }
 

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -9,27 +9,27 @@ struct GlobalReferenceVisitor<'a> {
     references: FxHashSet<SpirvWord>,
 }
 
-impl ast::VisitorMap<SpirvWord, SpirvWord, Infallible> for GlobalReferenceVisitor<'_> {
+impl ast::Visitor<SpirvWord, Infallible> for GlobalReferenceVisitor<'_> {
     fn visit(
         &mut self,
-        operand: SpirvWord,
+        operand: &SpirvWord,
         _type_space: Option<(&ast::Type, ast::StateSpace)>,
         _is_dst: bool,
         _relaxed_type_check: bool,
-    ) -> Result<SpirvWord, Infallible> {
-        self.record(operand);
-        Ok(operand)
+    ) -> Result<(), Infallible> {
+        self.record(*operand);
+        Ok(())
     }
 
     fn visit_ident(
         &mut self,
-        ident: SpirvWord,
+        ident: &SpirvWord,
         _type_space: Option<(&ast::Type, ast::StateSpace)>,
         _is_dst: bool,
         _relaxed_type_check: bool,
-    ) -> Result<SpirvWord, Infallible> {
-        self.record(ident);
-        Ok(ident)
+    ) -> Result<(), Infallible> {
+        self.record(*ident);
+        Ok(())
     }
 }
 
@@ -48,7 +48,7 @@ pub(super) struct DependencyGraph {
 
 impl DependencyGraph {
     pub(super) fn from_directives(
-        directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+        directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
     ) -> Self {
         let mut result = Self {
             graph: Graph::new(),
@@ -76,7 +76,7 @@ impl DependencyGraph {
             }
         }
 
-        for directive in directives.iter_mut() {
+        for directive in directives {
             match directive {
                 Directive2::Variable(_, variable) => {
                     for initializer in &variable.info.array_init {
@@ -86,7 +86,7 @@ impl DependencyGraph {
                     }
                 }
                 Directive2::Method(function) => {
-                    let Some(body) = function.body.as_mut() else {
+                    let Some(body) = &function.body else {
                         continue;
                     };
 
@@ -94,28 +94,18 @@ impl DependencyGraph {
                         globals: &globals,
                         references: FxHashSet::default(),
                     };
-                    let mut calls = FxHashSet::default();
 
-                    let old_body = std::mem::take(body);
-                    *body = old_body
-                        .into_iter()
-                        .map(|statement| {
-                            if let Statement::Instruction(ast::Instruction::Call {
-                                arguments,
-                                ..
-                            }) = &statement
-                            {
-                                calls.insert(arguments.func);
-                            }
+                    for statement in body {
+                        let Statement::Instruction(instruction) = statement else {
+                            continue;
+                        };
 
-                            statement
-                                .visit_map(&mut global_references)
-                                .expect("infallible global reference visitor")
-                        })
-                        .collect();
+                        ast::visit(instruction, &mut global_references)
+                            .expect("infallible global reference visitor");
 
-                    for callee in calls {
-                        result.add_dependency(function.name, callee);
+                        if let ast::Instruction::Call { arguments, .. } = instruction {
+                            result.add_dependency(function.name, arguments.func);
+                        }
                     }
 
                     for global in global_references.references {
@@ -187,7 +177,7 @@ pub(super) fn function_index<'a>(
 }
 
 pub(super) fn kernel_dependencies(
-    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
     let graph = DependencyGraph::from_directives(directives);
 
@@ -204,7 +194,7 @@ pub(super) fn kernel_dependencies(
 
 #[cfg(test)]
 pub(super) fn kernel_method_sets(
-    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
     kernel_dependencies(directives)
         .into_iter()
@@ -264,7 +254,7 @@ fn kernel_declaration_sets_from_dependencies(
 
 #[cfg(test)]
 pub(super) fn kernel_declaration_sets(
-    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
     let dependencies = kernel_dependencies(directives);
     kernel_declaration_sets_from_dependencies(directives, &dependencies)
@@ -294,8 +284,8 @@ pub(super) struct KernelCompilationPlan {
 pub(super) fn build_compilation_plan(
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> KernelCompilationPlan {
-    let mut directives = directives;
-    let reachable_symbols = kernel_dependencies(&mut directives);
+    let directives = directives;
+    let reachable_symbols = kernel_dependencies(&directives);
     let mut declaration_sets =
         kernel_declaration_sets_from_dependencies(&directives, &reachable_symbols);
     let globals = directives

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -100,14 +100,21 @@ impl DependencyGraph {
 
 pub(super) fn function_index<'a>(
     directives: &'a [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
-) -> FxHashMap<SpirvWord, &'a Function<ast::Instruction<SpirvWord>, SpirvWord>> {
-    directives
-        .iter()
-        .filter_map(|directive| match directive {
-            Directive2::Method(function) => Some((function.name, function)),
-            Directive2::Variable(..) => None,
-        })
-        .collect()
+) -> FxHashMap<SpirvWord, Vec<&'a Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
+    let mut functions: FxHashMap<
+        SpirvWord,
+        Vec<&'a Function<ast::Instruction<SpirvWord>, SpirvWord>>,
+    > = FxHashMap::default();
+
+    for directive in directives {
+        let Directive2::Method(function) = directive else {
+            continue;
+        };
+
+        functions.entry(function.name).or_default().push(function);
+    }
+
+    functions
 }
 
 pub(super) fn kernel_dependencies(
@@ -168,7 +175,14 @@ pub(super) fn kernel_declaration_sets(
                 .into_iter()
                 .filter(|method| *method != kernel)
                 .filter_map(|method| functions.get(&method))
-                .map(|function| method_declaration(function))
+                .filter_map(|functions| {
+                    functions
+                        .iter()
+                        .copied()
+                        .find(|function| function.body.is_some())
+                        .or_else(|| functions.first().copied())
+                })
+                .map(method_declaration)
                 .collect();
 
             (kernel, declarations)

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -285,11 +285,14 @@ pub(super) fn build_compilation_plan(
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> KernelCompilationPlan {
     let mut directives = directives;
+    let reachable_symbols = kernel_dependencies(&mut directives);
     let mut declaration_sets = kernel_declaration_sets(&mut directives);
-    let global_declarations = directives
+    let globals = directives
         .iter()
         .filter_map(|directive| match directive {
-            Directive2::Variable(linking, variable) => Some(global_declaration(*linking, variable)),
+            Directive2::Variable(linking, variable) => {
+                Some((variable.name, global_declaration(*linking, variable)))
+            }
             Directive2::Method(..) => None,
         })
         .collect::<Vec<_>>();
@@ -301,10 +304,20 @@ pub(super) fn build_compilation_plan(
             Directive2::Variable(..) => common.push(directive),
             Directive2::Method(function) if function.is_kernel() => {
                 let declarations = declaration_sets.remove(&function.name).unwrap_or_default();
+                let global_declarations = reachable_symbols
+                    .get(&function.name)
+                    .map(|reachable| {
+                        globals
+                            .iter()
+                            .filter(|(name, _)| reachable.contains(name))
+                            .map(|(_, declaration)| declaration.clone())
+                            .collect()
+                    })
+                    .unwrap_or_default();
 
                 kernels.push(KernelModulePlan {
                     kernel: function,
-                    global_declarations: global_declarations.clone(),
+                    global_declarations,
                     declarations,
                 });
             }

--- a/ptx/src/pass/kernel_dependencies.rs
+++ b/ptx/src/pass/kernel_dependencies.rs
@@ -2,6 +2,44 @@ use super::{Directive2, Function, SpirvWord, Statement};
 use petgraph::{graph::NodeIndex, visit::Dfs, Graph};
 use ptx_parser as ast;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::convert::Infallible;
+
+struct GlobalReferenceVisitor<'a> {
+    globals: &'a FxHashSet<SpirvWord>,
+    references: FxHashSet<SpirvWord>,
+}
+
+impl ast::VisitorMap<SpirvWord, SpirvWord, Infallible> for GlobalReferenceVisitor<'_> {
+    fn visit(
+        &mut self,
+        operand: SpirvWord,
+        _type_space: Option<(&ast::Type, ast::StateSpace)>,
+        _is_dst: bool,
+        _relaxed_type_check: bool,
+    ) -> Result<SpirvWord, Infallible> {
+        self.record(operand);
+        Ok(operand)
+    }
+
+    fn visit_ident(
+        &mut self,
+        ident: SpirvWord,
+        _type_space: Option<(&ast::Type, ast::StateSpace)>,
+        _is_dst: bool,
+        _relaxed_type_check: bool,
+    ) -> Result<SpirvWord, Infallible> {
+        self.record(ident);
+        Ok(ident)
+    }
+}
+
+impl GlobalReferenceVisitor<'_> {
+    fn record(&mut self, ident: SpirvWord) {
+        if self.globals.contains(&ident) {
+            self.references.insert(ident);
+        }
+    }
+}
 
 pub(super) struct DependencyGraph {
     graph: Graph<SpirvWord, ()>,
@@ -10,7 +48,7 @@ pub(super) struct DependencyGraph {
 
 impl DependencyGraph {
     pub(super) fn from_directives(
-        directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+        directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
     ) -> Self {
         let mut result = Self {
             graph: Graph::new(),
@@ -19,7 +57,15 @@ impl DependencyGraph {
 
         // Register all module-level symbols before adding edges. A function
         // declaration and its definition share the same SpirvWord node.
-        for directive in directives {
+        let globals = directives
+            .iter()
+            .filter_map(|directive| match directive {
+                Directive2::Variable(_, variable) => Some(variable.name),
+                Directive2::Method(_) => None,
+            })
+            .collect::<FxHashSet<_>>();
+
+        for directive in directives.iter() {
             match directive {
                 Directive2::Variable(_, variable) => {
                     result.add_node(variable.name);
@@ -30,7 +76,7 @@ impl DependencyGraph {
             }
         }
 
-        for directive in directives {
+        for directive in directives.iter_mut() {
             match directive {
                 Directive2::Variable(_, variable) => {
                     for initializer in &variable.info.array_init {
@@ -40,17 +86,40 @@ impl DependencyGraph {
                     }
                 }
                 Directive2::Method(function) => {
-                    let Some(body) = &function.body else {
+                    let Some(body) = function.body.as_mut() else {
                         continue;
                     };
 
-                    for statement in body {
-                        if let Statement::Instruction(ast::Instruction::Call {
-                            arguments, ..
-                        }) = statement
-                        {
-                            result.add_dependency(function.name, arguments.func);
-                        }
+                    let mut global_references = GlobalReferenceVisitor {
+                        globals: &globals,
+                        references: FxHashSet::default(),
+                    };
+                    let mut calls = FxHashSet::default();
+
+                    let old_body = std::mem::take(body);
+                    *body = old_body
+                        .into_iter()
+                        .map(|statement| {
+                            if let Statement::Instruction(ast::Instruction::Call {
+                                arguments,
+                                ..
+                            }) = &statement
+                            {
+                                calls.insert(arguments.func);
+                            }
+
+                            statement
+                                .visit_map(&mut global_references)
+                                .expect("infallible global reference visitor")
+                        })
+                        .collect();
+
+                    for callee in calls {
+                        result.add_dependency(function.name, callee);
+                    }
+
+                    for global in global_references.references {
+                        result.add_dependency(function.name, global);
                     }
                 }
             }
@@ -118,7 +187,7 @@ pub(super) fn function_index<'a>(
 }
 
 pub(super) fn kernel_dependencies(
-    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
     let graph = DependencyGraph::from_directives(directives);
 
@@ -134,7 +203,7 @@ pub(super) fn kernel_dependencies(
 }
 
 pub(super) fn kernel_method_sets(
-    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, FxHashSet<SpirvWord>> {
     kernel_dependencies(directives)
         .into_iter()
@@ -164,11 +233,12 @@ pub(super) fn method_declaration(
 }
 
 pub(super) fn kernel_declaration_sets(
-    directives: &[Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
+    directives: &mut [Directive2<ast::Instruction<SpirvWord>, SpirvWord>],
 ) -> FxHashMap<SpirvWord, Vec<Function<ast::Instruction<SpirvWord>, SpirvWord>>> {
+    let method_sets = kernel_method_sets(directives);
     let functions = function_index(directives);
 
-    kernel_method_sets(directives)
+    method_sets
         .into_iter()
         .map(|(kernel, methods)| {
             let declarations = methods
@@ -214,7 +284,8 @@ pub(super) struct KernelCompilationPlan {
 pub(super) fn build_compilation_plan(
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> KernelCompilationPlan {
-    let mut declaration_sets = kernel_declaration_sets(&directives);
+    let mut directives = directives;
+    let mut declaration_sets = kernel_declaration_sets(&mut directives);
     let global_declarations = directives
         .iter()
         .filter_map(|directive| match directive {

--- a/ptx/src/pass/llvm/emit.rs
+++ b/ptx/src/pass/llvm/emit.rs
@@ -240,7 +240,7 @@ impl<'a, 'input> ModuleEmitContext<'a, 'input> {
 
     fn emit_global(
         &mut self,
-        _linking: ast::LinkingDirective,
+        linking: ast::LinkingDirective,
         var: ast::Variable<SpirvWord>,
     ) -> Result<(), TranslateError> {
         let name = self
@@ -266,18 +266,31 @@ impl<'a, 'input> ModuleEmitContext<'a, 'input> {
                 get_state_space(var.info.state_space)?,
             )
         };
-        if matches!(var.info.v_type, ast::Type::Texref) {
+        let is_declaration = linking.contains(ast::LinkingDirective::EXTERN);
+
+        if matches!(var.info.v_type, ast::Type::Texref) && !is_declaration {
             unsafe { LLVMSetInitializer(global, LLVMGetUndef(llvm_type)) };
             unsafe {
                 LLVMSetAlignment(global, 8);
             }
         }
-        self.emit_linkage(global, &var.info)?;
+
+        if is_declaration {
+            unsafe {
+                LLVMSetLinkage(global, LLVMLinkage::LLVMExternalLinkage);
+                LLVMSetVisibility(global, LLVMVisibility::LLVMDefaultVisibility);
+            }
+        } else {
+            self.emit_linkage(global, &var.info)?;
+        }
+
         self.resolver.register(var.name, global);
+
         if let Some(align) = var.info.align {
             unsafe { LLVMSetAlignment(global, align) };
         }
-        if !var.info.array_init.is_empty() {
+
+        if !is_declaration && !var.info.array_init.is_empty() {
             let initializer = self.get_array_init(&var.info.v_type, &*var.info.array_init)?;
             unsafe { LLVMSetInitializer(global, initializer) };
         }

--- a/ptx/src/pass/llvm/emit.rs
+++ b/ptx/src/pass/llvm/emit.rs
@@ -64,11 +64,11 @@ impl Drop for Builder {
 
 pub(crate) fn run<'input>(
     context: &Context,
-    id_defs: GlobalStringIdentResolver2<'input>,
+    id_defs: &GlobalStringIdentResolver2<'input>,
     directives: Vec<Directive2<ast::Instruction<SpirvWord>, SpirvWord>>,
 ) -> Result<llvm::Module, TranslateError> {
     let module = llvm::Module::new(context, LLVM_UNNAMED);
-    let mut emit_ctx = ModuleEmitContext::new(context, &module, &id_defs);
+    let mut emit_ctx = ModuleEmitContext::new(context, &module, id_defs);
     for directive in directives {
         match directive {
             Directive2::Variable(linking, variable) => emit_ctx.emit_global(linking, variable)?,

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -114,7 +114,7 @@ pub fn to_llvm_module<'input>(
     on_pass_end("hoist_globals");
     let _kernel_method_sets = kernel_dependencies::kernel_method_sets(&directives);
     let context = llvm_zluda::utils::Context::new();
-    let llvm_ir = llvm::emit::run(&context, flat_resolver, directives)?;
+    let llvm_ir = llvm::emit::run(&context, &flat_resolver, directives)?;
     let attributes_ir = llvm::attributes::run(&context, attributes)?;
     on_pass_end("emit_llvm");
     Ok(Module {

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -19,6 +19,7 @@ mod insert_explicit_load_store;
 mod insert_implicit_conversions;
 mod insert_post_saturation;
 mod instruction_mode_to_global_mode;
+mod kernel_dependencies;
 pub mod llvm;
 mod normalize_basic_blocks;
 mod normalize_identifiers;
@@ -111,6 +112,7 @@ pub fn to_llvm_module<'input>(
     on_pass_end("replace_instructions_with_functions");
     let directives = hoist_globals::run(directives)?;
     on_pass_end("hoist_globals");
+    let _kernel_method_sets = kernel_dependencies::kernel_method_sets(&directives);
     let context = llvm_zluda::utils::Context::new();
     let llvm_ir = llvm::emit::run(&context, flat_resolver, directives)?;
     let attributes_ir = llvm::attributes::run(&context, attributes)?;

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -112,7 +112,7 @@ pub fn to_llvm_module<'input>(
     on_pass_end("replace_instructions_with_functions");
     let directives = hoist_globals::run(directives)?;
     on_pass_end("hoist_globals");
-    let _kernel_method_sets = kernel_dependencies::kernel_method_sets(&directives);
+    let _kernel_declaration_sets = kernel_dependencies::kernel_declaration_sets(&directives);
     let context = llvm_zluda::utils::Context::new();
     let llvm_ir = llvm::emit::run(&context, &flat_resolver, directives)?;
     let attributes_ir = llvm::attributes::run(&context, attributes)?;

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -59,6 +59,40 @@ pub struct Attributes {
     pub clock_rate: u32,
 }
 
+fn emit_compilation_plan<'input>(
+    context: &llvm_zluda::utils::Context,
+    id_defs: &GlobalStringIdentResolver2<'input>,
+    plan: kernel_dependencies::KernelCompilationPlan,
+) -> Result<llvm_zluda::utils::Module, TranslateError> {
+    let kernel_dependencies::KernelCompilationPlan { common, kernels } = plan;
+    let llvm_ir = llvm::emit::run(context, id_defs, common)?;
+
+    for kernel_dependencies::KernelModulePlan {
+        kernel,
+        global_declarations,
+        declarations,
+    } in kernels
+    {
+        let mut directives = Vec::with_capacity(global_declarations.len() + declarations.len() + 1);
+
+        directives.extend(
+            global_declarations
+                .into_iter()
+                .map(|(linking, variable)| Directive2::Variable(linking, variable)),
+        );
+        directives.extend(declarations.into_iter().map(Directive2::Method));
+        directives.push(Directive2::Method(kernel));
+
+        let kernel_ir = llvm::emit::run(context, id_defs, directives)?;
+
+        llvm_ir
+            .link(kernel_ir)
+            .map_err(|error| TranslateError::Todo(error.to_string()))?;
+    }
+
+    Ok(llvm_ir)
+}
+
 pub fn to_llvm_module<'input>(
     ast: ast::Module<'input>,
     attributes: Attributes,
@@ -113,9 +147,8 @@ pub fn to_llvm_module<'input>(
     let directives = hoist_globals::run(directives)?;
     on_pass_end("hoist_globals");
     let compilation_plan = kernel_dependencies::build_compilation_plan(directives);
-    let directives = compilation_plan.into_monolithic_directives();
     let context = llvm_zluda::utils::Context::new();
-    let llvm_ir = llvm::emit::run(&context, &flat_resolver, directives)?;
+    let llvm_ir = emit_compilation_plan(&context, &flat_resolver, compilation_plan)?;
     let attributes_ir = llvm::attributes::run(&context, attributes)?;
     on_pass_end("emit_llvm");
     Ok(Module {

--- a/ptx/src/pass/mod.rs
+++ b/ptx/src/pass/mod.rs
@@ -112,7 +112,8 @@ pub fn to_llvm_module<'input>(
     on_pass_end("replace_instructions_with_functions");
     let directives = hoist_globals::run(directives)?;
     on_pass_end("hoist_globals");
-    let _kernel_declaration_sets = kernel_dependencies::kernel_declaration_sets(&directives);
+    let compilation_plan = kernel_dependencies::build_compilation_plan(directives);
+    let directives = compilation_plan.into_monolithic_directives();
     let context = llvm_zluda::utils::Context::new();
     let llvm_ir = llvm::emit::run(&context, &flat_resolver, directives)?;
     let attributes_ir = llvm::attributes::run(&context, attributes)?;

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,0 +1,290 @@
+use super::super::kernel_dependencies::{
+    direct_callees, function_index, kernel_dependencies, kernel_method_sets, reachable_callees,
+};
+use super::super::*;
+
+#[test]
+fn extracts_direct_callee() {
+    let callee = SpirvWord(2);
+
+    let function = Function {
+        return_arguments: Vec::new(),
+        name: SpirvWord(1),
+        input_arguments: Vec::new(),
+        body: Some(vec![Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })]),
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let callees = direct_callees(&function);
+
+    assert_eq!(callees.len(), 1);
+    assert!(callees.contains(&callee));
+}
+
+#[test]
+fn declaration_has_no_callees() {
+    let function = Function {
+        return_arguments: Vec::new(),
+        name: SpirvWord(1),
+        input_arguments: Vec::new(),
+        body: None,
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    assert!(direct_callees(&function).is_empty());
+}
+
+#[test]
+fn finds_transitive_callees_from_function_index() {
+    let kernel_name = SpirvWord(1);
+    let helper_a_name = SpirvWord(2);
+    let helper_b_name = SpirvWord(3);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_a_name)]),
+        )),
+        Directive2::Method(make_function(
+            helper_a_name,
+            Some(vec![make_call(helper_b_name)]),
+        )),
+        Directive2::Method(make_function(helper_b_name, Some(Vec::new()))),
+    ];
+
+    let functions = function_index(&directives);
+    let reachable = reachable_callees(kernel_name, &functions);
+
+    assert_eq!(reachable.len(), 2);
+    assert!(reachable.contains(&helper_a_name));
+    assert!(reachable.contains(&helper_b_name));
+    assert!(!reachable.contains(&kernel_name));
+}
+
+#[test]
+fn excludes_root_when_call_graph_contains_cycle() {
+    let root_name = SpirvWord(1);
+    let helper_name = SpirvWord(2);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, callee| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body: Some(vec![make_call(callee)]),
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(root_name, helper_name)),
+        Directive2::Method(make_function(helper_name, root_name)),
+    ];
+
+    let functions = function_index(&directives);
+    let reachable = reachable_callees(root_name, &functions);
+
+    assert_eq!(reachable.len(), 1);
+    assert!(reachable.contains(&helper_name));
+    assert!(!reachable.contains(&root_name));
+}
+
+#[test]
+fn computes_dependencies_for_each_kernel() {
+    let kernel_name = SpirvWord(1);
+    let helper_a_name = SpirvWord(2);
+    let helper_b_name = SpirvWord(3);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_a_name)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(
+            helper_a_name,
+            Some(vec![make_call(helper_b_name)]),
+            None,
+        )),
+        Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
+    ];
+
+    let dependencies = kernel_dependencies(&directives);
+    let kernel_callees = dependencies
+        .get(&kernel_name)
+        .expect("kernel dependency entry should exist");
+
+    assert_eq!(dependencies.len(), 1);
+    assert_eq!(kernel_callees.len(), 2);
+    assert!(kernel_callees.contains(&helper_a_name));
+    assert!(kernel_callees.contains(&helper_b_name));
+    assert!(!kernel_callees.contains(&kernel_name));
+}
+
+#[test]
+fn includes_kernel_in_its_method_set() {
+    let kernel_name = SpirvWord(1);
+    let helper_a_name = SpirvWord(2);
+    let helper_b_name = SpirvWord(3);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_a_name)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(
+            helper_a_name,
+            Some(vec![make_call(helper_b_name)]),
+            None,
+        )),
+        Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
+    ];
+
+    let method_sets = kernel_method_sets(&directives);
+    let methods = method_sets
+        .get(&kernel_name)
+        .expect("kernel method set should exist");
+
+    assert_eq!(method_sets.len(), 1);
+    assert_eq!(methods.len(), 3);
+    assert!(methods.contains(&kernel_name));
+    assert!(methods.contains(&helper_a_name));
+    assert!(methods.contains(&helper_b_name));
+}

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,6 +1,7 @@
 use super::super::kernel_dependencies::{
-    build_compilation_plan, direct_callees, function_index, kernel_declaration_sets,
-    kernel_dependencies, kernel_method_sets, method_declaration, reachable_callees,
+    build_compilation_plan, direct_callees, function_index, global_declaration,
+    kernel_declaration_sets, kernel_dependencies, kernel_method_sets, method_declaration,
+    reachable_callees,
 };
 use super::super::*;
 
@@ -618,4 +619,88 @@ fn monolithic_conversion_restores_definitions_without_declarations() {
         Directive2::Method(function)
             if function.name == helper_name && function.body.is_none()
     )));
+}
+
+#[test]
+fn global_declaration_removes_initializer() {
+    let global_name = SpirvWord(1);
+    let variable = ast::Variable {
+        name: global_name,
+        info: ast::VariableInfo {
+            align: Some(8),
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init: vec![ast::RegOrImmediate::Imm(ast::ImmediateValue::U64(42))],
+        },
+    };
+
+    let (linking, declaration) = global_declaration(ast::LinkingDirective::VISIBLE, &variable);
+
+    assert!(linking.contains(ast::LinkingDirective::VISIBLE));
+    assert_eq!(declaration.name, global_name);
+    assert_eq!(declaration.info.align, Some(8));
+    assert!(declaration.info.array_init.is_empty());
+
+    assert_eq!(variable.info.array_init.len(), 1);
+}
+
+#[test]
+fn compilation_plan_adds_global_declarations_to_each_kernel() {
+    let global_name = SpirvWord(1);
+    let first_kernel_name = SpirvWord(2);
+    let second_kernel_name = SpirvWord(3);
+
+    let make_kernel = |name| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body: Some(Vec::new()),
+        kernel_attributes: Some(KernelAttributes {
+            flush_to_zero_f32: false,
+            flush_to_zero_f16f64: false,
+            rounding_mode_f32: ast::RoundingMode::NearestEven,
+            rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+        }),
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let global = ast::Variable {
+        name: global_name,
+        info: ast::VariableInfo {
+            align: None,
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init: vec![ast::RegOrImmediate::Imm(ast::ImmediateValue::U64(7))],
+        },
+    };
+
+    let directives = vec![
+        Directive2::Variable(ast::LinkingDirective::VISIBLE, global),
+        Directive2::Method(make_kernel(first_kernel_name)),
+        Directive2::Method(make_kernel(second_kernel_name)),
+    ];
+
+    let plan = build_compilation_plan(directives);
+
+    assert_eq!(plan.kernels.len(), 2);
+
+    for kernel_plan in &plan.kernels {
+        assert_eq!(kernel_plan.global_declarations.len(), 1);
+
+        let (linking, declaration) = &kernel_plan.global_declarations[0];
+
+        assert!(linking.contains(ast::LinkingDirective::VISIBLE));
+        assert_eq!(declaration.name, global_name);
+        assert!(declaration.info.array_init.is_empty());
+    }
+
+    assert!(matches!(
+        &plan.common[0],
+        Directive2::Variable(_, variable)
+            if variable.name == global_name
+                && variable.info.array_init.len() == 1
+    ));
 }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,5 +1,6 @@
 use super::super::kernel_dependencies::{
-    direct_callees, function_index, kernel_dependencies, kernel_method_sets, reachable_callees,
+    direct_callees, function_index, kernel_declaration_sets, kernel_dependencies,
+    kernel_method_sets, method_declaration, reachable_callees,
 };
 use super::super::*;
 
@@ -287,4 +288,110 @@ fn includes_kernel_in_its_method_set() {
     assert!(methods.contains(&kernel_name));
     assert!(methods.contains(&helper_a_name));
     assert!(methods.contains(&helper_b_name));
+}
+
+#[test]
+fn creates_bodyless_helper_declaration() {
+    let helper_name = SpirvWord(10);
+    let input_name = SpirvWord(11);
+    let return_name = SpirvWord(12);
+
+    let helper = Function {
+        return_arguments: vec![ast::Variable {
+            name: return_name,
+            info: ast::VariableInfo {
+                align: None,
+                v_type: ast::Type::Scalar(ast::ScalarType::U32),
+                state_space: ast::StateSpace::Param,
+                array_init: Vec::new(),
+            },
+        }],
+        name: helper_name,
+        input_arguments: vec![ast::Variable {
+            name: input_name,
+            info: ast::VariableInfo {
+                align: None,
+                v_type: ast::Type::Scalar(ast::ScalarType::U32),
+                state_space: ast::StateSpace::Param,
+                array_init: Vec::new(),
+            },
+        }],
+        body: Some(Vec::new()),
+        kernel_attributes: None,
+        import_as: None,
+        tuning: vec![ast::TuningDirective::NoReturn],
+        linkage: ast::LinkingDirective::VISIBLE,
+        kernel_meta32: None,
+    };
+
+    let declaration = method_declaration(&helper);
+
+    assert_eq!(declaration.name, helper_name);
+    assert_eq!(declaration.return_arguments.len(), 1);
+    assert_eq!(declaration.input_arguments.len(), 1);
+    assert!(declaration.body.is_none());
+    assert!(!declaration.is_kernel());
+
+    assert!(helper.body.is_some());
+}
+
+#[test]
+fn builds_helper_declarations_for_kernel() {
+    let kernel_name = SpirvWord(1);
+    let helper_name = SpirvWord(2);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_name)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
+    ];
+
+    let declaration_sets = kernel_declaration_sets(&directives);
+    let declarations = declaration_sets
+        .get(&kernel_name)
+        .expect("kernel declaration set should exist");
+
+    assert_eq!(declaration_sets.len(), 1);
+    assert_eq!(declarations.len(), 1);
+    assert_eq!(declarations[0].name, helper_name);
+    assert!(declarations[0].body.is_none());
+    assert!(!declarations[0].is_kernel());
 }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -637,6 +637,7 @@ fn global_declaration_removes_initializer() {
     let (linking, declaration) = global_declaration(ast::LinkingDirective::VISIBLE, &variable);
 
     assert!(linking.contains(ast::LinkingDirective::VISIBLE));
+    assert!(linking.contains(ast::LinkingDirective::EXTERN));
     assert_eq!(declaration.name, global_name);
     assert_eq!(declaration.info.align, Some(8));
     assert!(declaration.info.array_init.is_empty());
@@ -693,6 +694,7 @@ fn compilation_plan_adds_global_declarations_to_each_kernel() {
         let (linking, declaration) = &kernel_plan.global_declarations[0];
 
         assert!(linking.contains(ast::LinkingDirective::VISIBLE));
+        assert!(linking.contains(ast::LinkingDirective::EXTERN));
         assert_eq!(declaration.name, global_name);
         assert!(declaration.info.array_init.is_empty());
     }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,6 +1,6 @@
 use super::super::kernel_dependencies::{
-    direct_callees, function_index, kernel_declaration_sets, kernel_dependencies,
-    kernel_method_sets, method_declaration, reachable_callees,
+    build_compilation_plan, direct_callees, function_index, kernel_declaration_sets,
+    kernel_dependencies, kernel_method_sets, method_declaration, reachable_callees,
 };
 use super::super::*;
 
@@ -394,4 +394,228 @@ fn builds_helper_declarations_for_kernel() {
     assert_eq!(declarations[0].name, helper_name);
     assert!(declarations[0].body.is_none());
     assert!(!declarations[0].is_kernel());
+}
+
+#[test]
+fn compilation_plan_separates_kernels_from_common_directives() {
+    let global_name = SpirvWord(1);
+    let kernel_name = SpirvWord(2);
+    let helper_name = SpirvWord(3);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let global = ast::Variable {
+        name: global_name,
+        info: ast::VariableInfo {
+            align: None,
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init: Vec::new(),
+        },
+    };
+
+    let directives = vec![
+        Directive2::Variable(ast::LinkingDirective::NONE, global),
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_name)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
+    ];
+
+    let plan = build_compilation_plan(directives);
+
+    assert_eq!(plan.common.len(), 2);
+    assert_eq!(plan.kernels.len(), 1);
+
+    assert!(matches!(
+        &plan.common[0],
+        Directive2::Variable(_, variable) if variable.name == global_name
+    ));
+    assert!(matches!(
+        &plan.common[1],
+        Directive2::Method(function) if function.name == helper_name
+    ));
+
+    let kernel_plan = &plan.kernels[0];
+
+    assert_eq!(kernel_plan.kernel.name, kernel_name);
+    assert!(kernel_plan.kernel.is_kernel());
+    assert_eq!(kernel_plan.declarations.len(), 1);
+    assert_eq!(kernel_plan.declarations[0].name, helper_name);
+    assert!(kernel_plan.declarations[0].body.is_none());
+    assert!(!kernel_plan.declarations[0].is_kernel());
+}
+
+#[test]
+fn compilation_plan_includes_only_reachable_helper_declarations() {
+    let kernel_name = SpirvWord(1);
+    let reachable_helper = SpirvWord(2);
+    let unreachable_helper = SpirvWord(3);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(reachable_helper)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(reachable_helper, Some(Vec::new()), None)),
+        Directive2::Method(make_function(unreachable_helper, Some(Vec::new()), None)),
+    ];
+
+    let plan = build_compilation_plan(directives);
+    let kernel_plan = &plan.kernels[0];
+
+    assert_eq!(kernel_plan.declarations.len(), 1);
+    assert_eq!(kernel_plan.declarations[0].name, reachable_helper);
+
+    assert!(plan.common.iter().any(|directive| matches!(
+        directive,
+        Directive2::Method(function) if function.name == reachable_helper
+    )));
+    assert!(plan.common.iter().any(|directive| matches!(
+        directive,
+        Directive2::Method(function) if function.name == unreachable_helper
+    )));
+}
+
+#[test]
+fn monolithic_conversion_restores_definitions_without_declarations() {
+    let kernel_name = SpirvWord(1);
+    let helper_name = SpirvWord(2);
+
+    let make_call = |callee| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: callee,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![make_call(helper_name)]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
+    ];
+
+    let restored = build_compilation_plan(directives).into_monolithic_directives();
+
+    assert_eq!(restored.len(), 2);
+
+    assert!(restored.iter().any(|directive| matches!(
+        directive,
+        Directive2::Method(function)
+            if function.name == helper_name && function.body.is_some()
+    )));
+
+    assert!(restored.iter().any(|directive| matches!(
+        directive,
+        Directive2::Method(function)
+            if function.name == kernel_name && function.is_kernel()
+    )));
+
+    assert!(!restored.iter().any(|directive| matches!(
+        directive,
+        Directive2::Method(function)
+            if function.name == helper_name && function.body.is_none()
+    )));
 }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -493,16 +493,29 @@ fn global_declaration_removes_initializer() {
 }
 
 #[test]
-fn compilation_plan_adds_global_declarations_to_each_kernel() {
+fn compilation_plan_adds_reachable_global_declarations_to_each_kernel() {
     let global_name = SpirvWord(1);
     let first_kernel_name = SpirvWord(2);
     let second_kernel_name = SpirvWord(3);
+    let destination = SpirvWord(4);
 
     let make_kernel = |name| Function {
         return_arguments: Vec::new(),
         name,
         input_arguments: Vec::new(),
-        body: Some(Vec::new()),
+        body: Some(vec![Statement::Instruction(ast::Instruction::Ld {
+            data: ast::LdDetails {
+                qualifier: ast::LdStQualifier::Weak,
+                state_space: ast::StateSpace::Global,
+                caching: ast::LdCacheOperator::Cached,
+                typ: ast::Type::Scalar(ast::ScalarType::U32),
+                non_coherent: false,
+            },
+            arguments: ast::LdArgs {
+                dst: destination,
+                src: global_name,
+            },
+        })]),
         kernel_attributes: Some(KernelAttributes {
             flush_to_zero_f32: false,
             flush_to_zero_f16f64: false,

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -45,7 +45,7 @@ fn computes_dependencies_for_each_kernel() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_a_name)]),
@@ -59,7 +59,7 @@ fn computes_dependencies_for_each_kernel() {
         Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
     ];
 
-    let dependencies = kernel_dependencies(&mut directives);
+    let dependencies = kernel_dependencies(&directives);
     let kernel_callees = dependencies
         .get(&kernel_name)
         .expect("kernel dependency entry should exist");
@@ -112,7 +112,7 @@ fn includes_kernel_in_its_method_set() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_a_name)]),
@@ -126,7 +126,7 @@ fn includes_kernel_in_its_method_set() {
         Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
     ];
 
-    let method_sets = kernel_method_sets(&mut directives);
+    let method_sets = kernel_method_sets(&directives);
     let methods = method_sets
         .get(&kernel_name)
         .expect("kernel method set should exist");
@@ -223,7 +223,7 @@ fn builds_helper_declarations_for_kernel() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_name)]),
@@ -232,7 +232,7 @@ fn builds_helper_declarations_for_kernel() {
         Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
     ];
 
-    let declaration_sets = kernel_declaration_sets(&mut directives);
+    let declaration_sets = kernel_declaration_sets(&directives);
     let declarations = declaration_sets
         .get(&kernel_name)
         .expect("kernel declaration set should exist");
@@ -592,7 +592,7 @@ fn dependency_graph_unifies_function_declaration_and_definition() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Method(make_function(helper_name, None, None)),
         Directive2::Method(make_function(
             kernel_name,
@@ -602,7 +602,7 @@ fn dependency_graph_unifies_function_declaration_and_definition() {
         Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
     ];
 
-    let graph = DependencyGraph::from_directives(&mut directives);
+    let graph = DependencyGraph::from_directives(&directives);
     let reachable = graph.reachable_from(kernel_name);
 
     assert_eq!(reachable.len(), 1);
@@ -624,7 +624,7 @@ fn dependency_graph_tracks_global_initializer_dependencies() {
         },
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Variable(
             ast::LinkingDirective::NONE,
             variable(source_name, Vec::new()),
@@ -635,7 +635,7 @@ fn dependency_graph_tracks_global_initializer_dependencies() {
         ),
     ];
 
-    let graph = DependencyGraph::from_directives(&mut directives);
+    let graph = DependencyGraph::from_directives(&directives);
     let reachable = graph.reachable_from(dependent_name);
 
     assert_eq!(reachable.len(), 1);
@@ -713,12 +713,12 @@ fn dependency_graph_tracks_global_references_in_function_body() {
         kernel_meta32: None,
     };
 
-    let mut directives = vec![
+    let directives = vec![
         Directive2::Variable(ast::LinkingDirective::NONE, global),
         Directive2::Method(function),
     ];
 
-    let graph = DependencyGraph::from_directives(&mut directives);
+    let graph = DependencyGraph::from_directives(&directives);
     let reachable = graph.reachable_from(function_name);
 
     assert_eq!(reachable.len(), 1);

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,161 +1,8 @@
 use super::super::kernel_dependencies::{
-    build_compilation_plan, direct_callees, function_index, global_declaration,
-    kernel_declaration_sets, kernel_dependencies, kernel_method_sets, method_declaration,
-    reachable_callees,
+    build_compilation_plan, global_declaration, kernel_declaration_sets, kernel_dependencies,
+    kernel_method_sets, method_declaration, DependencyGraph,
 };
 use super::super::*;
-
-#[test]
-fn extracts_direct_callee() {
-    let callee = SpirvWord(2);
-
-    let function = Function {
-        return_arguments: Vec::new(),
-        name: SpirvWord(1),
-        input_arguments: Vec::new(),
-        body: Some(vec![Statement::Instruction(ast::Instruction::Call {
-            data: ast::CallDetails {
-                uniform: false,
-                return_arguments: Vec::new(),
-                input_arguments: Vec::new(),
-            },
-            arguments: ast::CallArgs {
-                return_arguments: Vec::new(),
-                func: callee,
-                input_arguments: Vec::new(),
-                is_external: false,
-            },
-        })]),
-        kernel_attributes: None,
-        import_as: None,
-        tuning: Vec::new(),
-        linkage: ast::LinkingDirective::NONE,
-        kernel_meta32: None,
-    };
-
-    let callees = direct_callees(&function);
-
-    assert_eq!(callees.len(), 1);
-    assert!(callees.contains(&callee));
-}
-
-#[test]
-fn declaration_has_no_callees() {
-    let function = Function {
-        return_arguments: Vec::new(),
-        name: SpirvWord(1),
-        input_arguments: Vec::new(),
-        body: None,
-        kernel_attributes: None,
-        import_as: None,
-        tuning: Vec::new(),
-        linkage: ast::LinkingDirective::NONE,
-        kernel_meta32: None,
-    };
-
-    assert!(direct_callees(&function).is_empty());
-}
-
-#[test]
-fn finds_transitive_callees_from_function_index() {
-    let kernel_name = SpirvWord(1);
-    let helper_a_name = SpirvWord(2);
-    let helper_b_name = SpirvWord(3);
-
-    let make_call = |callee| {
-        Statement::Instruction(ast::Instruction::Call {
-            data: ast::CallDetails {
-                uniform: false,
-                return_arguments: Vec::new(),
-                input_arguments: Vec::new(),
-            },
-            arguments: ast::CallArgs {
-                return_arguments: Vec::new(),
-                func: callee,
-                input_arguments: Vec::new(),
-                is_external: false,
-            },
-        })
-    };
-
-    let make_function = |name, body| Function {
-        return_arguments: Vec::new(),
-        name,
-        input_arguments: Vec::new(),
-        body,
-        kernel_attributes: None,
-        import_as: None,
-        tuning: Vec::new(),
-        linkage: ast::LinkingDirective::NONE,
-        kernel_meta32: None,
-    };
-
-    let directives = vec![
-        Directive2::Method(make_function(
-            kernel_name,
-            Some(vec![make_call(helper_a_name)]),
-        )),
-        Directive2::Method(make_function(
-            helper_a_name,
-            Some(vec![make_call(helper_b_name)]),
-        )),
-        Directive2::Method(make_function(helper_b_name, Some(Vec::new()))),
-    ];
-
-    let functions = function_index(&directives);
-    let reachable = reachable_callees(kernel_name, &functions);
-
-    assert_eq!(reachable.len(), 2);
-    assert!(reachable.contains(&helper_a_name));
-    assert!(reachable.contains(&helper_b_name));
-    assert!(!reachable.contains(&kernel_name));
-}
-
-#[test]
-fn excludes_root_when_call_graph_contains_cycle() {
-    let root_name = SpirvWord(1);
-    let helper_name = SpirvWord(2);
-
-    let make_call = |callee| {
-        Statement::Instruction(ast::Instruction::Call {
-            data: ast::CallDetails {
-                uniform: false,
-                return_arguments: Vec::new(),
-                input_arguments: Vec::new(),
-            },
-            arguments: ast::CallArgs {
-                return_arguments: Vec::new(),
-                func: callee,
-                input_arguments: Vec::new(),
-                is_external: false,
-            },
-        })
-    };
-
-    let make_function = |name, callee| Function {
-        return_arguments: Vec::new(),
-        name,
-        input_arguments: Vec::new(),
-        body: Some(vec![make_call(callee)]),
-        kernel_attributes: None,
-        import_as: None,
-        tuning: Vec::new(),
-        linkage: ast::LinkingDirective::NONE,
-        kernel_meta32: None,
-    };
-
-    let directives = vec![
-        Directive2::Method(make_function(root_name, helper_name)),
-        Directive2::Method(make_function(helper_name, root_name)),
-    ];
-
-    let functions = function_index(&directives);
-    let reachable = reachable_callees(root_name, &functions);
-
-    assert_eq!(reachable.len(), 1);
-    assert!(reachable.contains(&helper_name));
-    assert!(!reachable.contains(&root_name));
-}
 
 #[test]
 fn computes_dependencies_for_each_kernel() {
@@ -705,4 +552,92 @@ fn compilation_plan_adds_global_declarations_to_each_kernel() {
             if variable.name == global_name
                 && variable.info.array_init.len() == 1
     ));
+}
+
+#[test]
+fn dependency_graph_unifies_function_declaration_and_definition() {
+    let kernel_name = SpirvWord(1);
+    let helper_name = SpirvWord(2);
+
+    let call = Statement::Instruction(ast::Instruction::Call {
+        data: ast::CallDetails {
+            uniform: false,
+            return_arguments: Vec::new(),
+            input_arguments: Vec::new(),
+        },
+        arguments: ast::CallArgs {
+            return_arguments: Vec::new(),
+            func: helper_name,
+            input_arguments: Vec::new(),
+            is_external: false,
+        },
+    });
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(helper_name, None, None)),
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![call]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
+    ];
+
+    let graph = DependencyGraph::from_directives(&directives);
+    let reachable = graph.reachable_from(kernel_name);
+
+    assert_eq!(reachable.len(), 1);
+    assert!(reachable.contains(&helper_name));
+}
+
+#[test]
+fn dependency_graph_tracks_global_initializer_dependencies() {
+    let source_name = SpirvWord(1);
+    let dependent_name = SpirvWord(2);
+
+    let variable = |name, array_init| ast::Variable {
+        name,
+        info: ast::VariableInfo {
+            align: None,
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init,
+        },
+    };
+
+    let directives = vec![
+        Directive2::Variable(
+            ast::LinkingDirective::NONE,
+            variable(source_name, Vec::new()),
+        ),
+        Directive2::Variable(
+            ast::LinkingDirective::NONE,
+            variable(dependent_name, vec![ast::RegOrImmediate::Reg(source_name)]),
+        ),
+    ];
+
+    let graph = DependencyGraph::from_directives(&directives);
+    let reachable = graph.reachable_from(dependent_name);
+
+    assert_eq!(reachable.len(), 1);
+    assert!(reachable.contains(&source_name));
 }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -797,3 +797,73 @@ fn compilation_plan_includes_only_reachable_global_declarations() {
     assert_eq!(globals.len(), 1);
     assert_eq!(globals[0].1.name, reachable_global);
 }
+
+#[test]
+fn kernel_declarations_preserve_directive_order() {
+    let kernel_name = SpirvWord(1);
+    let first_helper_name = SpirvWord(2);
+    let second_helper_name = SpirvWord(3);
+
+    let make_call = |function| {
+        Statement::Instruction(ast::Instruction::Call {
+            data: ast::CallDetails {
+                uniform: false,
+                return_arguments: Vec::new(),
+                input_arguments: Vec::new(),
+            },
+            arguments: ast::CallArgs {
+                return_arguments: Vec::new(),
+                func: function,
+                input_arguments: Vec::new(),
+                is_external: false,
+            },
+        })
+    };
+
+    let make_function = |name, body, kernel_attributes| Function {
+        return_arguments: Vec::new(),
+        name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let kernel_attributes = KernelAttributes {
+        flush_to_zero_f32: false,
+        flush_to_zero_f16f64: false,
+        rounding_mode_f32: ast::RoundingMode::NearestEven,
+        rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(
+            kernel_name,
+            Some(vec![
+                make_call(second_helper_name),
+                make_call(first_helper_name),
+            ]),
+            Some(kernel_attributes),
+        )),
+        Directive2::Method(make_function(first_helper_name, Some(Vec::new()), None)),
+        Directive2::Method(make_function(second_helper_name, Some(Vec::new()), None)),
+    ];
+
+    let declaration_sets = kernel_declaration_sets(&directives);
+    let declarations = declaration_sets
+        .get(&kernel_name)
+        .expect("kernel declaration set should exist");
+
+    let declaration_names = declarations
+        .iter()
+        .map(|declaration| declaration.name)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        declaration_names,
+        vec![first_helper_name, second_helper_name]
+    );
+}

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -1,6 +1,6 @@
 use super::super::kernel_dependencies::{
-    build_compilation_plan, global_declaration, kernel_declaration_sets, kernel_dependencies,
-    kernel_method_sets, method_declaration, DependencyGraph,
+    build_compilation_plan, function_index, global_declaration, kernel_declaration_sets,
+    kernel_dependencies, kernel_method_sets, method_declaration, DependencyGraph,
 };
 use super::super::*;
 
@@ -640,4 +640,35 @@ fn dependency_graph_tracks_global_initializer_dependencies() {
 
     assert_eq!(reachable.len(), 1);
     assert!(reachable.contains(&source_name));
+}
+
+#[test]
+fn function_index_preserves_declaration_and_definition() {
+    let function_name = SpirvWord(1);
+
+    let make_function = |body| Function {
+        return_arguments: Vec::new(),
+        name: function_name,
+        input_arguments: Vec::new(),
+        body,
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let directives = vec![
+        Directive2::Method(make_function(None)),
+        Directive2::Method(make_function(Some(Vec::new()))),
+    ];
+
+    let functions = function_index(&directives);
+    let entries = functions
+        .get(&function_name)
+        .expect("function should be indexed");
+
+    assert_eq!(entries.len(), 2);
+    assert!(entries.iter().any(|function| function.body.is_none()));
+    assert!(entries.iter().any(|function| function.body.is_some()));
 }

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -725,3 +725,62 @@ fn dependency_graph_tracks_global_references_in_function_body() {
     assert!(reachable.contains(&global_name));
     assert!(!reachable.contains(&destination));
 }
+
+#[test]
+fn compilation_plan_includes_only_reachable_global_declarations() {
+    let reachable_global = SpirvWord(1);
+    let unreachable_global = SpirvWord(2);
+    let kernel_name = SpirvWord(3);
+    let destination = SpirvWord(4);
+
+    let variable = |name| ast::Variable {
+        name,
+        info: ast::VariableInfo {
+            align: None,
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init: Vec::new(),
+        },
+    };
+
+    let kernel = Function {
+        return_arguments: Vec::new(),
+        name: kernel_name,
+        input_arguments: Vec::new(),
+        body: Some(vec![Statement::Instruction(ast::Instruction::Ld {
+            data: ast::LdDetails {
+                qualifier: ast::LdStQualifier::Weak,
+                state_space: ast::StateSpace::Global,
+                caching: ast::LdCacheOperator::Cached,
+                typ: ast::Type::Scalar(ast::ScalarType::U32),
+                non_coherent: false,
+            },
+            arguments: ast::LdArgs {
+                dst: destination,
+                src: reachable_global,
+            },
+        })]),
+        kernel_attributes: Some(KernelAttributes {
+            flush_to_zero_f32: false,
+            flush_to_zero_f16f64: false,
+            rounding_mode_f32: ast::RoundingMode::NearestEven,
+            rounding_mode_f16f64: ast::RoundingMode::NearestEven,
+        }),
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let plan = build_compilation_plan(vec![
+        Directive2::Variable(ast::LinkingDirective::NONE, variable(reachable_global)),
+        Directive2::Variable(ast::LinkingDirective::NONE, variable(unreachable_global)),
+        Directive2::Method(kernel),
+    ]);
+
+    assert_eq!(plan.kernels.len(), 1);
+
+    let globals = &plan.kernels[0].global_declarations;
+    assert_eq!(globals.len(), 1);
+    assert_eq!(globals[0].1.name, reachable_global);
+}

--- a/ptx/src/pass/test/kernel_dependencies.rs
+++ b/ptx/src/pass/test/kernel_dependencies.rs
@@ -45,7 +45,7 @@ fn computes_dependencies_for_each_kernel() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let directives = vec![
+    let mut directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_a_name)]),
@@ -59,7 +59,7 @@ fn computes_dependencies_for_each_kernel() {
         Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
     ];
 
-    let dependencies = kernel_dependencies(&directives);
+    let dependencies = kernel_dependencies(&mut directives);
     let kernel_callees = dependencies
         .get(&kernel_name)
         .expect("kernel dependency entry should exist");
@@ -112,7 +112,7 @@ fn includes_kernel_in_its_method_set() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let directives = vec![
+    let mut directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_a_name)]),
@@ -126,7 +126,7 @@ fn includes_kernel_in_its_method_set() {
         Directive2::Method(make_function(helper_b_name, Some(Vec::new()), None)),
     ];
 
-    let method_sets = kernel_method_sets(&directives);
+    let method_sets = kernel_method_sets(&mut directives);
     let methods = method_sets
         .get(&kernel_name)
         .expect("kernel method set should exist");
@@ -223,7 +223,7 @@ fn builds_helper_declarations_for_kernel() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let directives = vec![
+    let mut directives = vec![
         Directive2::Method(make_function(
             kernel_name,
             Some(vec![make_call(helper_name)]),
@@ -232,7 +232,7 @@ fn builds_helper_declarations_for_kernel() {
         Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
     ];
 
-    let declaration_sets = kernel_declaration_sets(&directives);
+    let declaration_sets = kernel_declaration_sets(&mut directives);
     let declarations = declaration_sets
         .get(&kernel_name)
         .expect("kernel declaration set should exist");
@@ -592,7 +592,7 @@ fn dependency_graph_unifies_function_declaration_and_definition() {
         rounding_mode_f16f64: ast::RoundingMode::NearestEven,
     };
 
-    let directives = vec![
+    let mut directives = vec![
         Directive2::Method(make_function(helper_name, None, None)),
         Directive2::Method(make_function(
             kernel_name,
@@ -602,7 +602,7 @@ fn dependency_graph_unifies_function_declaration_and_definition() {
         Directive2::Method(make_function(helper_name, Some(Vec::new()), None)),
     ];
 
-    let graph = DependencyGraph::from_directives(&directives);
+    let graph = DependencyGraph::from_directives(&mut directives);
     let reachable = graph.reachable_from(kernel_name);
 
     assert_eq!(reachable.len(), 1);
@@ -624,7 +624,7 @@ fn dependency_graph_tracks_global_initializer_dependencies() {
         },
     };
 
-    let directives = vec![
+    let mut directives = vec![
         Directive2::Variable(
             ast::LinkingDirective::NONE,
             variable(source_name, Vec::new()),
@@ -635,7 +635,7 @@ fn dependency_graph_tracks_global_initializer_dependencies() {
         ),
     ];
 
-    let graph = DependencyGraph::from_directives(&directives);
+    let graph = DependencyGraph::from_directives(&mut directives);
     let reachable = graph.reachable_from(dependent_name);
 
     assert_eq!(reachable.len(), 1);
@@ -671,4 +671,57 @@ fn function_index_preserves_declaration_and_definition() {
     assert_eq!(entries.len(), 2);
     assert!(entries.iter().any(|function| function.body.is_none()));
     assert!(entries.iter().any(|function| function.body.is_some()));
+}
+
+#[test]
+fn dependency_graph_tracks_global_references_in_function_body() {
+    let global_name = SpirvWord(1);
+    let function_name = SpirvWord(2);
+    let destination = SpirvWord(3);
+
+    let global = ast::Variable {
+        name: global_name,
+        info: ast::VariableInfo {
+            align: None,
+            v_type: ast::Type::Scalar(ast::ScalarType::U32),
+            state_space: ast::StateSpace::Global,
+            array_init: Vec::new(),
+        },
+    };
+
+    let function = Function {
+        return_arguments: Vec::new(),
+        name: function_name,
+        input_arguments: Vec::new(),
+        body: Some(vec![Statement::Instruction(ast::Instruction::Ld {
+            data: ast::LdDetails {
+                qualifier: ast::LdStQualifier::Weak,
+                state_space: ast::StateSpace::Global,
+                caching: ast::LdCacheOperator::Cached,
+                typ: ast::Type::Scalar(ast::ScalarType::U32),
+                non_coherent: false,
+            },
+            arguments: ast::LdArgs {
+                dst: destination,
+                src: global_name,
+            },
+        })]),
+        kernel_attributes: None,
+        import_as: None,
+        tuning: Vec::new(),
+        linkage: ast::LinkingDirective::NONE,
+        kernel_meta32: None,
+    };
+
+    let mut directives = vec![
+        Directive2::Variable(ast::LinkingDirective::NONE, global),
+        Directive2::Method(function),
+    ];
+
+    let graph = DependencyGraph::from_directives(&mut directives);
+    let reachable = graph.reachable_from(function_name);
+
+    assert_eq!(reachable.len(), 1);
+    assert!(reachable.contains(&global_name));
+    assert!(!reachable.contains(&destination));
 }

--- a/ptx/src/pass/test/mod.rs
+++ b/ptx/src/pass/test/mod.rs
@@ -1,3 +1,4 @@
+mod kernel_dependencies;
 use ptx_parser as ast;
 use std::{
     env, error,


### PR DESCRIPTION
## What this changes

This PR splits PTX LLVM emission into a common module and separate modules for each kernel.

The common module keeps the global variables and helper function definitions. Each kernel module contains the kernel itself, declarations for the helper functions it calls, and extern declarations for the globals it may reference. The kernel modules are then linked back into the common module.

## Why

The current emission path builds one LLVM module from all transformed PTX directives. This change introduces the structure needed to compile kernels separately without cloning the transformed instruction bodies.

## Implementation notes

- tracks direct and transitive helper dependencies for each kernel;
- creates body-less declarations for reachable helper functions;
- builds an ownership-based compilation plan so definitions are moved only once;
- creates extern global declarations for kernel modules;
- emits each kernel module separately and links it into the common module.

The monolithic reconstruction path is kept only for tests.

## Validation

I ran:

- `cargo check -p ptx`
- `cargo check -p ptx --tests`
- `cargo build -p compiler --bin zoc`

I also compiled these PTX files through LLVM linking and ELF generation:

- `ptx/src/test/spirv_run/add.ptx`
- `ptx/src/test/spirv_run/call.ptx`
- `ptx/src/test/spirv_run/global_array.ptx`
- `ptx/src/test/spirv_run/extern_shared_call.ptx`
- `ptx/src/test/spirv_run/32/add.ptx`

The generated LLVM IR retained the helper definitions, global initializers, external shared declarations, and kernel calls as expected.
Opening this as a draft to get feedback on the module ownership and linking approach before expanding the test coverage.

## Part of #652 
This implements the compilation-unit splitting and linking groundwork for #652.

Each kernel is now emitted as a separate LLVM module with the required helper and global declarations, then linked into the common module. The current implementation still emits the kernel modules sequentially. Parallel scheduling of those compilation units is not included in this PR.