### PR TITLE
Enable Windows Job Objects APIs

### DIFF
--- a/.github/workflows/pr_master.yml
+++ b/.github/workflows/pr_master.yml
@@ -79,8 +79,6 @@ jobs:
         submodules: true
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
-    - name: Test Windows support crate
-      run: cargo test -p zluda_windows --lib
     - name: Build
       run: |
         cargo xtask zip --profile ${{ env.CARGO_PROFILE }}

--- a/.github/workflows/pr_master.yml
+++ b/.github/workflows/pr_master.yml
@@ -79,6 +79,8 @@ jobs:
         submodules: true
     - name: Run sccache-cache
       uses: mozilla-actions/sccache-action@v0.0.9
+    - name: Test Windows support crate
+      run: cargo test -p zluda_windows --lib
     - name: Build
       run: |
         cargo xtask zip --profile ${{ env.CARGO_PROFILE }}

--- a/zluda_windows/Cargo.toml
+++ b/zluda_windows/Cargo.toml
@@ -16,7 +16,10 @@ alloca = "0.4.0"
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = [
     "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
     "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Controls"


### PR DESCRIPTION
## Summary

Declare the Windows API feature groups required by ZLUDA's existing Job Objects
calls, and test the Windows support crate independently in pull-request CI.

## Root cause

`zluda_windows` uses Job Object APIs but did not declare the corresponding
Windows crate feature groups. Full workspace builds can hide this because Cargo
unifies features requested by other crates; an independent `zluda_windows`
build then fails to compile.

## Impact

Restores standalone Windows builds of `zluda_windows` and prevents this
dependency-feature regression from being masked by unrelated workspace crates.

## Validation

- `cargo test -p zluda_windows --lib --locked`
  - 6 passed
